### PR TITLE
Beginning of injection using dart:mirrors

### DIFF
--- a/lib/dice.dart
+++ b/lib/dice.dart
@@ -8,6 +8,8 @@
 library dice;
 
 import "package:meta/meta.dart";
+import "dart:async";
+import "dart:mirrors";
 
 part "src/binder.dart";
 part "src/injector.dart";

--- a/lib/src/binder.dart
+++ b/lib/src/binder.dart
@@ -24,6 +24,10 @@ class Binder {
     _builder = builder;
   }
   
+  toClassMirror(ClassMirror mirror) {
+    _builder = () => mirror;
+  }
+  
   TypeBuilder _builder;
 }
 
@@ -31,4 +35,3 @@ class Binder {
  * Function that builds instance of a bound types
  */
 typedef dynamic TypeBuilder();
-

--- a/lib/src/injector.dart
+++ b/lib/src/injector.dart
@@ -4,30 +4,96 @@
 
 part of dice;
 
+
 /**
  * Resolve types to their implementing classes
  */
-class Injector {
-  Injector(this._module) {
+abstract class Injector {
+  factory Injector(module) => new InjectorImpl(module);
+  
+  Future<dynamic> getInstance(Type type);
+}
+/**
+ * Implementation of [Injector].
+ */
+class InjectorImpl implements Injector {
+  Module _module;
+
+  InjectorImpl(this._module) {
     _module.configure();
     _module.injector = this;
   }
   
-  dynamic getInstance(Type type) {
+  Future<dynamic> getInstance(Type type) {
     if(!_module._hasBindingFor(type)) {
       /*
        * TODO when dart:mirrors support it change this code to create new instance from type 
        * and use reflection to resolve its sub dependencies
        */
-       throw new ArgumentError("no instance registered for type $type");
+      throw new ArgumentError("no instance registered for type $type");
     }
     
     var binder = _module._getBindingFor(type);
     // TODO use reflection to resolve sub dependencies when dart:mirrors support access to meta information
-    return binder._builder();
+    // TODO avoid circular references using a cache or injecting proxies
+    var instance = binder._builder();
+    instance = inject(instance);
+    return instance;
   }
   
-  Module _module;
+  Future<dynamic> inject(dynamic instance) {
+    return (instance is ClassMirror ? newInstance(instance) : new Future.immediate(reflect(instance)))
+        .then(injectSetters)
+        .then(injectVariables)
+        .then((InstanceMirror instanceMirror) => instanceMirror.reflectee);
+  }
+  
+  Future<InstanceMirror> newInstance(ClassMirror classMirror) {
+    // Look for an injectable constructor
+    var constructors = injectableConstructors(classMirror);
+    // that has the greatest number of parameters to inject, optional included
+    MethodMirror constructor = constructors.reduce(null, 
+        (MethodMirror p, MethodMirror e) => 
+            p == null || p.parameters.where(injectable).length < e.parameters.where(injectable).length ? e : p);
+    String constructorName = constructor.simpleName.replaceFirst(classMirror.simpleName, "").replaceFirst(".", "");
+    
+    // TODO parameters injection
+    return classMirror.newInstance(constructorName, []);
+  }
+  
+  Future<InstanceMirror> injectSetters(InstanceMirror instanceMirror) {
+      var setters = injectableSetters(instanceMirror.type);
+      // FIXME We are not able to get Type from a TypeMirror yet
+      var futures = setters.map((s) => inject(s.parameters[0].type).then((instance) => 
+          instanceMirror.setField(s.simpleName.substring(0, s.simpleName.length - 1), reflect(instance)))); 
+      // setters.forEach((s) => instanceMirror.invoke(s.simpleName, [getInstance(s.returnType)])); 
+      return Future.wait(futures).then((_) => instanceMirror);
+  }
+  
+  Future<InstanceMirror> injectVariables(InstanceMirror instanceMirror) {
+      var variables = injectableVariables(instanceMirror.type);
+      // FIXME We are not able to get Type from a TypeMirror yet
+      var futures = variables.map((v) => inject(v.type).then((instance) => 
+          instanceMirror.setField(v.simpleName, reflect(instance)))); 
+      // variables.forEach((v) => instanceMirror.setField(v.simpleName, getInstance(v.type)));
+      return Future.wait(futures).then((_) => instanceMirror);
+  }
+  
+  /** Returns constructors that could be injected */
+  Iterable<MethodMirror> injectableConstructors(ClassMirror classMirror) =>
+      // All non optional parameters should be injectable
+      classMirror.constructors.values.where((m) => m.parameters.where((p) => !p.isOptional).every(injectable));
+
+  /** Returns setters that need injection */
+  Iterable<MethodMirror> injectableSetters(ClassMirror classMirror) => 
+      classMirror.setters.values.where((m) => injectable(m) || m.parameters.every(injectable));
+
+  /** Returns variables that need injection */
+  Iterable<VariableMirror> injectableVariables(ClassMirror classMirror) => 
+      classMirror.variables.values.where(injectable);
+
+  /** Returns true if the declared [element] is injectable */
+  bool injectable(DeclarationMirror element) => element.simpleName.startsWith('\$') || element.simpleName.startsWith('_\$');
 }
 
 /**
@@ -38,5 +104,3 @@ const inject = const _Inject();
 class _Inject {
   const _Inject();
 }
-
-

--- a/test/dice_test.dart
+++ b/test/dice_test.dart
@@ -5,6 +5,8 @@
 library dice_test;
 
 import "../lib/dice.dart";
+import "dart:async";
+import "dart:mirrors";
 import "package:meta/meta.dart";
 import "package:unittest/unittest.dart";
 
@@ -16,28 +18,100 @@ main() {
     var injector = new Injector(new MyModule());
     
     test("singleton", () {
-      var instance = injector.getInstance(MyClass);
-      expect(instance, isNotNull);
-      expect(instance.getName(), equals("MyClass"));
-      expect(identical(instance, injector.getInstance(MyClass)), isTrue, reason:"must be singleton");
+      injector.getInstance(MyClass).then(expectAsync1((instance) {
+        expect(instance, isNotNull);
+        expect(instance.getName(), equals("MyClass"));
+        injector.getInstance(MyClass).then(expectAsync1((secondInstance) {
+          expect(identical(instance, secondInstance), isTrue, reason:"must be singleton");
+        }));
+      }));
     });
     
     test("instance", () {
-      var instance = injector.getInstance(MyOtherClass);
-      expect(instance, isNotNull);
-      expect(instance.getName(), equals("MyOtherClass"));
-      expect(identical(instance, injector.getInstance(MyOtherClass)), isFalse, reason:"must be new instance");
+      injector.getInstance(MyOtherClass).then(expectAsync1((instance) {
+        expect(instance, isNotNull);
+        expect(instance.getName(), equals("MyOtherClass"));
+        expect(identical(instance, injector.getInstance(MyOtherClass)), isFalse, reason:"must be new instance");
+      }));
     });
     
     test("function", () {
-      var func = injector.getInstance(MyFunction);
-      expect(func, isNotNull);
-      expect(func(), equals("MyFunction"));
+      injector.getInstance(MyFunction).then(expectAsync1((func) {
+        expect(func, isNotNull);
+        expect(func(), equals("MyFunction"));
+      }));
     });
+    
+    test("class mirror", () {
+      injector.getInstance(MyClassToInject).then(expectAsync1((MyClassToInject instance) {
+        expect(instance, isNotNull);
+        expect(instance, new isInstanceOf<MyClassToInject>('MyClassToInject'));
+        expect(instance.$variableToInject, isNotNull);
+        expect(instance._$variableToInject, isNotNull);
+        expect(instance.injections['\$setterToInject'], isNotNull);
+        expect(instance.injections['_\$setterToInject'], isNotNull);
+        // FIXME: Until parameters names are supported (returns TODO:unnamed)
+        // expect(instance.injections['setterToInject'], isNotNull);
+        // expect(instance.injections['_setterToInject'], isNotNull);
+      }));
+    });
+    
   });
   
   group("annotation injection", () {
     // TODO test annotations
+  });
+  
+  group("Members to inject -", () {
+    InjectorImpl injector = new InjectorImpl(new MyModule());
+    
+    ClassMirror classMirror = reflect(new MyClassToInject()).type;
+
+    test("new instance of MyClass", () {
+      ClassMirror classMirror = reflect(new MyClass()).type;
+      injector.newInstance(classMirror).then(expectAsync1((InstanceMirror instance) {
+        expect(instance, isNotNull);
+        expect(instance.reflectee, isNotNull);
+        expect(instance.reflectee, new isInstanceOf<MyClass>('MyClass'));
+      }));
+    });
+
+    test("new instance of MyClassToInject", () {
+      ClassMirror classMirror = reflect(new MyClassToInject()).type;
+      injector.newInstance(classMirror).then(expectAsync1((InstanceMirror instance) {
+        expect(instance, isNotNull);
+        expect(instance.reflectee, isNotNull);
+        expect(instance.reflectee, new isInstanceOf<MyClassToInject>('MyClassToInject'));
+      }));
+    });
+    
+    test("constructors", () {
+      var c = classMirror.constructors;
+      Iterable<MethodMirror> constructors = injector.injectableConstructors(classMirror).toList();
+      Iterable<MethodMirror> expected = [c["MyClassToInject"]];
+      // FIXME: should be this but parameters names are not supported yet (returns TODO:unnamed)
+      // Iterable<MethodMirror> expected = [c["MyClassToInject"], c["MyClassToInject.inject"], c["MyClassToInject.injectComplex"]];
+      
+      expect(constructors, unorderedEquals(expected));
+    });
+    
+    test("setters", () {
+      var s = classMirror.setters;
+      Iterable<MethodMirror> setters = injector.injectableSetters(classMirror).toList();
+      Iterable<MethodMirror> expected = [s["\$setterToInject="], s["_\$setterToInject="]];
+      // FIXME: should be this but parameters names are not supported yet (returns TODO:unnamed)
+      // Iterable<MethodMirror> expected = [s["setterToInject="], s["_setterToInject="], s["\$setterToInject="], s["_\$setterToInject="]];
+      
+      expect(setters, unorderedEquals(expected));
+    });
+    
+    test("variables", () {
+      var v = classMirror.variables;
+      Iterable<VariableMirror> variables = injector.injectableVariables(classMirror).toList();
+      Iterable<VariableMirror> expected = [v["\$variableToInject"], v["_\$variableToInject"]];
+      
+      expect(variables, unorderedEquals(expected));
+    });
   });
 }
 

--- a/test/test_module.dart
+++ b/test/test_module.dart
@@ -11,6 +11,7 @@ class MyModule extends Module {
     bind(MyClass).toInstance(new MyClass());
     bind(MyOtherClass).toBuilder(() => new MyOtherClass());
     bind(MyFunction).toInstance(_myFunction);
+    bind(MyClassToInject).toClassMirror(reflect(new MyClassToInject()).type);
   }
   
   String _myFunction() => "MyFunction";
@@ -22,6 +23,28 @@ class MyClass {
 
 class MyOtherClass {
   String getName() => "MyOtherClass";
+}
+
+class MyClassToInject {
+  // Map to trace injections from setters or constructors
+  Map injections = new Map();
+  
+  MyClass variableNotToInject;
+  MyClass _variableNotToInject;
+  MyClass $variableToInject;
+  MyClass _$variableToInject;
+  
+  MyClassToInject();
+  MyClassToInject.inject(this.$variableToInject);
+  MyClassToInject.notInject(this.$variableToInject, int other);
+  MyClassToInject.injectComplex(this.$variableToInject, MyClass $injectableParameter, {MyClass $optionalInject});
+  
+  set setterToInject(MyClass $setterToInject) => injections['setterToInject'] = $setterToInject;
+  set _setterToInject(MyClass $setterToInject) => injections['_setterToInject'] = $setterToInject;
+  set $setterToInject(MyClass setterToInject) => injections['\$setterToInject'] = setterToInject;
+  set _$setterToInject(MyClass setterToInject) => injections['_\$setterToInject'] = setterToInject;
+  set setterNotToInject(MyClass setterNotToInject) => injections['setterNotToInject'] = setterNotToInject;
+  set _setterNotToInject(MyClass setterNotToInject) => injections['_setterNotToInject'] = setterNotToInject;
 }
 
 typedef String MyFunction();


### PR DESCRIPTION
Let me know what you think about.

Here's my changes: 
- Injector.getInstance now returns a Future.
- Changed Injector to an abstract class and created InjectorImpl. The implementation is hidden and it's easier to test directly than private methods.
- Inject into variables and setters prefixed with $ or _$
- Added toClassMirror in Binder. I think it's not the best way how I've done it, maybe a specific implementation as ClassMirrorBinder could be better.

Limitation of dart:mirrors:references
- Parameter name doesn't work, it returns "TODO:unnamed" : I'd like to inject dependencies into setters or constructors with prefixed parameters instead of prefixed name.
- We are not able to get Type from a TypeMirror, and TypeMirror from Type

To do:
- Injection into constructors
- Check if a variable is final, static, ...
- Tests with inherired class
- How to manage singleton?
- How to manage circular references?
