### PR TITLE
Added default Registration type

### DIFF
--- a/lib/src/Registration.dart
+++ b/lib/src/Registration.dart
@@ -6,6 +6,11 @@ part of dice;
 
 /** Registration between a [Type] and its instance creation. */
 class Registration {
+  /** Create Registration defaulting to [type] */
+  Registration(Type type) {
+    toType(type);
+  }
+  
   /** Register object [instance] that will be returned when the type is requested */
   toInstance(var instance) {
     if(!_isClass(instance)) {

--- a/lib/src/module.dart
+++ b/lib/src/module.dart
@@ -11,7 +11,7 @@ abstract class Module {
   
   /** register a [type] with [name] to an implementation */
   Registration namedRegister(Type type, String name) {
-    var registration = new Registration();
+    var registration = new Registration(type);
     var typeMirrorWrapper = new TypeMirrorWrapper.fromType(type, name);
     _registrations[typeMirrorWrapper] = registration;
     return registration;


### PR DESCRIPTION
I added a default Registration type making *register(MyClass).toType(MyClass)* unnecessary. So after a simple *register(MyClass)* you can call *Injector.getInstance(MyClass)*. Maybe you want to merge that change!?