### PR TITLE
Name parameter and registration/unregistration at runtime at Injector level

### DIFF
--- a/lib/dice.dart
+++ b/lib/dice.dart
@@ -7,6 +7,7 @@ library dice;
 
 @MirrorsUsed(symbols: const ['inject', 'Named'])
 import 'dart:mirrors';
+import 'dart:collection';
 
 part 'src/annotations.dart';
 part 'src/Registration.dart';

--- a/lib/src/injector.dart
+++ b/lib/src/injector.dart
@@ -9,11 +9,8 @@ abstract class Injector {
   factory Injector(Module module) => new InjectorImpl(module);
   factory Injector.fromModules(List<Module> modules) => new InjectorImpl(new _ModuleContainer(modules));
 
-  /** Get new instance of [type] with dependencies resolved */
-  dynamic getInstance(Type type);
-  
-  /** Get new instance of [type] with [name] and all dependencies resolved */
-  dynamic getNamedInstance(Type type, String name);
+  /** Get new instance of [type] with [name] (optional) and all dependencies resolved */
+  dynamic getInstance(Type type, [String name]);
   
   /** Resolve injetions in existing Object (does not create a new instance) */
   Object resolveInjections(Object obj);
@@ -29,13 +26,7 @@ class InjectorImpl implements Injector {
   }
   
   @override
-  dynamic getInstance(Type type) {
-    var typeMirror = reflectClass(type);
-    return _getInstanceFor(typeMirror);
-  }
-  
-  @override
-  dynamic getNamedInstance(Type type, String name) {
+  dynamic getInstance(Type type, [String name = null]) {
     var typeMirror = reflectClass(type);
     return _getInstanceFor(typeMirror, name);
   }

--- a/lib/src/injector.dart
+++ b/lib/src/injector.dart
@@ -8,7 +8,6 @@ part of dice;
 abstract class Injector {
   factory Injector([Module module = null]) => new InjectorImpl(module);
   
-  @deprecated
   factory Injector.fromModules(List<Module> modules) => new InjectorImpl(new _ModuleContainer(modules));
   
   factory Injector.fromInjectors(List<Injector> injectors) {
@@ -20,6 +19,7 @@ abstract class Injector {
       }
     })
     );
+    return injector;
   }
   
   /** register a [type] with [name] (optional) to an implementation */
@@ -34,10 +34,6 @@ abstract class Injector {
   /** Resolve injetions in existing Object (does not create a new instance) */
   Object resolveInjections(Object obj);
   
-  /** Get the module used to configure this injector */
-  @deprecated
-  Module get module;
-  
   /** Get unmodifiable map of registrations */
   Map<TypeMirrorWrapper, Registration> get registrations;
 }
@@ -45,12 +41,11 @@ abstract class Injector {
 /** Implementation of [Injector]. */
 class InjectorImpl implements Injector {
   final Map<TypeMirrorWrapper, Registration> _registrations = new Map<TypeMirrorWrapper, Registration>();
-  final Module _module;
   
-  InjectorImpl([this._module = null]) {
-    if (_module != null) {
-      _module.configure();
-      _registrations.addAll(_module._registrations);
+  InjectorImpl([module = null]) {
+    if (module != null) {
+      module.configure();
+      _registrations.addAll(module._registrations);
     }
   }
   
@@ -84,9 +79,6 @@ class InjectorImpl implements Injector {
     var instanceMirror = reflect(obj);
     return _resolveInjections(instanceMirror);
   }
-  
-  @override
-  Module get module => _module;
   
   @override
   Map<TypeMirrorWrapper, Registration> get registrations => new UnmodifiableMapView(_registrations);

--- a/lib/src/injector.dart
+++ b/lib/src/injector.dart
@@ -14,7 +14,7 @@ abstract class Injector {
   factory Injector.fromInjectors(List<Injector> injectors) {
     var injector = new InjectorImpl();
     injectors.forEach((ijtor) =>
-      ijtor._registrations.forEach((typeMirrorWrapper, registration) {
+      ijtor.registrations.forEach((typeMirrorWrapper, registration) {
       if(!injector._registrations.containsKey(typeMirrorWrapper)) {
         injector._registrations[typeMirrorWrapper] = registration;
       }
@@ -34,6 +34,9 @@ abstract class Injector {
   /** Get the module used to configure this injector */
   @deprecated
   Module get module;
+  
+  /** Get unmodifiable map of registrations */
+  Map<TypeMirrorWrapper, Registration> get registrations;
 }
 
 /** Implementation of [Injector]. */
@@ -74,6 +77,9 @@ class InjectorImpl implements Injector {
   
   @override
   Module get module => _module;
+  
+  @override
+  Map<TypeMirrorWrapper, Registration> get registrations => new UnmodifiableMapView(_registrations);
   
   dynamic _getInstanceFor(TypeMirror tm, [String name = null]) {
     if(!_hasRegistrationFor(tm, name)) {

--- a/lib/src/injector.dart
+++ b/lib/src/injector.dart
@@ -23,7 +23,10 @@ abstract class Injector {
   }
   
   /** register a [type] with [name] (optional) to an implementation */
-  Registration register(Type type, [String name ]);
+  Registration register(Type type, [String name]);
+  
+  /** unregister a [type] and [name] (optional), returns [true] if registration has been removed*/
+  bool unregister(Type type, [String name]);
 
   /** Get new instance of [type] with [name] (optional) and all dependencies resolved */
   dynamic getInstance(Type type, [String name]);
@@ -59,9 +62,16 @@ class InjectorImpl implements Injector {
     return registration;
   }
   
+  @override
+  bool unregister(Type type, [String name = null]) {
+    return _removeRegistrationFor(reflectType(type), name) != null;
+  }
+  
   bool _hasRegistrationFor(TypeMirror type, String name) => _registrations.containsKey(new TypeMirrorWrapper(type, name));
   
   Registration _getRegistrationFor(TypeMirror type, String name) => _registrations[new TypeMirrorWrapper(type, name)];
+  
+  Registration _removeRegistrationFor(TypeMirror type, String name) => _registrations.remove(new TypeMirrorWrapper(type, name));
   
   @override
   dynamic getInstance(Type type, [String name = null]) {

--- a/lib/src/module.dart
+++ b/lib/src/module.dart
@@ -6,11 +6,9 @@ part of dice;
 
 /** Associates types with their concrete instances returned by the [Injector] */
 abstract class Module {
-  /** Register a [type] to an implementation */
-  Registration register(Type type) => namedRegister(type, null);
   
-  /** register a [type] with [name] to an implementation */
-  Registration namedRegister(Type type, String name) {
+  /** register a [type] with [name] (optional) to an implementation */
+  Registration register(Type type, [String name = null]) {
     var registration = new Registration(type);
     var typeMirrorWrapper = new TypeMirrorWrapper.fromType(type, name);
     _registrations[typeMirrorWrapper] = registration;

--- a/lib/src/module.dart
+++ b/lib/src/module.dart
@@ -5,6 +5,7 @@
 part of dice;
 
 /** Associates types with their concrete instances returned by the [Injector] */
+@deprecated
 abstract class Module {
   
   /** register a [type] with [name] (optional) to an implementation */

--- a/lib/src/module.dart
+++ b/lib/src/module.dart
@@ -5,7 +5,6 @@
 part of dice;
 
 /** Associates types with their concrete instances returned by the [Injector] */
-@deprecated
 abstract class Module {
   
   /** register a [type] with [name] (optional) to an implementation */

--- a/test/dice_test.dart
+++ b/test/dice_test.dart
@@ -91,6 +91,50 @@ main() {
     });
   });
   
+  group('register/unregister -', () {
+    var injector = new Injector();
+    injector
+      ..register(MyClass).toType(MySpecialClass)
+      ..register(YourClass)
+      ..register(MyOtherClass)
+      ..register(MyClass, 'test').toType(MySpecialClass);
+    
+    test('get instances', () {
+      var myClass = injector.getInstance(MyClass);
+      var yourClass = injector.getInstance(YourClass);
+      var myOtherClass = injector.getInstance(MyOtherClass);
+
+      expect(myClass, new isInstanceOf<MySpecialClass>());
+      expect(yourClass, new isInstanceOf<YourClass>());
+      expect(myOtherClass, new isInstanceOf<MyOtherClass>());
+    });
+    
+    test('unregister runtime', () {
+      injector.unregister(MyClass);
+      injector.unregister(YourClass);
+      injector.unregister(MyOtherClass);
+      
+      var myNamedClass = injector.getInstance(MyClass, 'test');
+      
+      expect(() => injector.getInstance(MyClass), throwsArgumentError);
+      expect(() => injector.getInstance(YourClass), throwsArgumentError);
+      expect(() => injector.getInstance(MyOtherClass), throwsArgumentError);
+      expect(myNamedClass, new isInstanceOf<MySpecialClass>());
+    });
+    
+    test('register runtime', () {
+      injector
+        ..register(MyClass).toType(MySpecialClass)
+        ..register(YourClass);
+      
+      var myClass = injector.getInstance(MyClass);
+      var yourClass = injector.getInstance(YourClass);
+      
+      expect(myClass, new isInstanceOf<MySpecialClass>());
+      expect(yourClass, new isInstanceOf<YourClass>());
+    });
+  });
+  
   group('internals -', () {
     var injector = new InjectorImpl(new MyModule());
     var classMirror = reflectClass(MyClassToInject);

--- a/test/dice_test.dart
+++ b/test/dice_test.dart
@@ -60,7 +60,7 @@ main() {
     
     test('named injections', () {
       var myClass = injector.getInstance(MyClass);
-      var mySpecialClass = injector.getNamedInstance(MyClass, "MySpecialClass");
+      var mySpecialClass = injector.getInstance(MyClass, "MySpecialClass");
       expect(myClass is MyClass, isTrue);
       expect(myClass is! MySpecialClass, isTrue);
       expect(mySpecialClass is MyClass, isTrue);

--- a/test/dice_test.dart
+++ b/test/dice_test.dart
@@ -86,7 +86,7 @@ main() {
       var injector = new Injector(myModule);
       expect(() => injector.getInstance(YourClass), throwsArgumentError);
       
-      injector.module.register(YourClass).toType(YourClass);
+      injector.register(YourClass).toType(YourClass);
       expect(injector.getInstance(YourClass), new isInstanceOf<YourClass>());
     });
   });

--- a/test/src/test_module.dart
+++ b/test/src/test_module.dart
@@ -11,7 +11,7 @@ class MyModule extends Module {
     register(MyClassToInject);
     
     // named
-    namedRegister(MyClass, "MySpecialClass").toType(MySpecialClass);
+    register(MyClass, "MySpecialClass").toType(MySpecialClass);
   }
 }
 


### PR DESCRIPTION
Hi,

I hacked a bit on your code and made changes that may be usefull for outhers too, but it breaks compatibility in some cases.

*23dcabd* just resolves issue #11 

The other changesets move the registration map from modules to the Injector. It makes unregistration at runtime possible and allows registration without subclassing a module. Example:

```
var injector = new Injector();
      injector
        ..register(MyClass).toType(MySpecialClass)
        ..register(YourClass)
        ..register(MyClass, 'test').toType(MySpecialClass);

var myClass = injector.getInstance(MyClass);
var yourClass = injector.getInstance(YourClass);

injector.unregister(MyClass);
injector.unregister(YourClass);

var myNamedClass = injector.getInstance(MyClass, 'test');
```