### PR TITLE
Singleton binding added, Module-installation added

### DIFF
--- a/lib/src/Registration.dart
+++ b/lib/src/Registration.dart
@@ -4,42 +4,54 @@
 
 part of dice;
 
-/** Registration between a [Type] and its instance creation. */
+/// Registration between a [Type] and its instance creation.
 class Registration {
-  /** Create Registration defaulting to [type] */
-  Registration(Type type) {
-    toType(type);
-  }
 
-  /** Register object [instance] that will be returned when the type is requested */
-  toInstance(var instance) {
-    if(!_isClass(instance)) {
-      throw new ArgumentError("only objects can be bound using 'toInstance'");
+    /// Create Registration defaulting to [type] */
+    Registration(Type type) {
+        toType(type);
     }
-    _builder = () => instance;
-  }
 
-  /** Register a [function] that will be returned when the type is requested */
-  toFunction(var function) {
-    if(_isClass(function)) {
-      throw new ArgumentError("only functions can be bound using 'toFunction'");
+    /// Register object [instance] that will be returned when the type is requested
+    void toInstance(var instance) {
+        if (!_isClass(instance)) {
+            throw new ArgumentError("only objects can be bound using 'toInstance'");
+        }
+        _builder = () => instance;
     }
-    _builder = () => function;
-  }
 
-  /** Register a [InstanceBuilder] that will emit new instances when the type is requested */
-  toBuilder(TypeBuilder builder) {
-    _builder = builder;
-  }
+    /// Register a [function] that will be returned when the type is requested
+    void toFunction(var function) {
+        if (_isClass(function)) {
+            throw new ArgumentError("only functions can be bound using 'toFunction'");
+        }
+        _builder = () => function;
+    }
 
-  /** Register a [type] that will be instantiated when the type is requested */
-  toType(Type type) {
-    _builder = () => type;
-  }
+    /// Register a [InstanceBuilder] that will emit new instances when the type is requested
+    void toBuilder(TypeBuilder builder) {
+        _builder = builder;
+    }
 
-  bool _isClass(var instance) => reflect(instance).type is! FunctionTypeMirror;
+    /// Register a [type] that will be instantiated when the type is requested
+    Registration toType(Type type) {
+        _builder = () => type;
+        return this;
+    }
 
-  TypeBuilder _builder;
+    /// Create only one instance
+    void asSingleton() {
+        _asSingleton = true;
+    }
+
+    bool _isClass(var instance) => reflect(instance).type is! FunctionTypeMirror;
+
+    TypeBuilder _builder;
+
+    bool _asSingleton = false;
+
+    /// Remember the instance in case we marked the Registration for "singleton"
+    var _instance = null;
 }
 
 /** Function that builds instance of a bound types */

--- a/lib/src/module.dart
+++ b/lib/src/module.dart
@@ -4,41 +4,47 @@
 
 part of dice;
 
-/** Associates types with their concrete instances returned by the [Injector] */
+/// Associates types with their concrete instances returned by the [Injector]
 abstract class Module {
+    
+    ///  register a [type] with [name] (optional) to an implementation
+    Registration register(Type type, [String name = null]) {
+        var registration = new Registration(type);
+        var typeMirrorWrapper = new TypeMirrorWrapper.fromType(type, name);
+        _registrations[typeMirrorWrapper] = registration;
+        return registration;
+    }
 
-  /** register a [type] with [name] (optional) to an implementation */
-  Registration register(Type type, [String name = null]) {
-    var registration = new Registration(type);
-    var typeMirrorWrapper = new TypeMirrorWrapper.fromType(type, name);
-    _registrations[typeMirrorWrapper] = registration;
-    return registration;
-  }
+    /// Configure type/instance registrations used in this module
+    configure();
 
-  /** Configure type/instace registrations used in this module */
-  configure();
+    /// Copies all bindings of [module] into this one.
+    /// Overwriting when conflicts are found.
+    void install(final Module module) {
+        module.configure();
+        _registrations.addAll(module._registrations);
+    }
 
-  bool _hasRegistrationFor(TypeMirror type, String name) => _registrations.containsKey(new TypeMirrorWrapper(type, name));
+    bool _hasRegistrationFor(TypeMirror type, String name) =>
+        _registrations.containsKey(new TypeMirrorWrapper(type, name));
 
-  Registration _getRegistrationFor(TypeMirror type, String name) => _registrations[new TypeMirrorWrapper(type, name)];
+    Registration _getRegistrationFor(TypeMirror type, String name) => _registrations[new TypeMirrorWrapper(type, name)];
 
-  final Map<TypeMirrorWrapper, Registration> _registrations = new Map<TypeMirrorWrapper, Registration>();
+    final Map<TypeMirrorWrapper, Registration> _registrations = new Map<TypeMirrorWrapper, Registration>();
 }
 
-/**
- * Combines several [Module] into single one, allowing to inject
- * a class from one module into a class from another module.
- */
+/// Combines several [Module] into single one, allowing to inject
+/// a class from one module into a class from another module.
 class _ModuleContainer extends Module {
-  _ModuleContainer(List<Module> this._modules);
+    _ModuleContainer(List<Module> this._modules);
 
-  @override
-  configure() {
-    _modules.fold(_registrations, (acc, module) {
-      module.configure();
-      return acc..addAll(module._registrations);
-    });
-  }
+    @override
+    configure() {
+        _modules.fold(_registrations, (acc, module) {
+            module.configure();
+            return acc..addAll(module._registrations);
+        });
+    }
 
-  List<Module> _modules;
+    List<Module> _modules;
 }

--- a/test/dice_test.dart
+++ b/test/dice_test.dart
@@ -12,163 +12,198 @@ import 'package:dice/dice.dart';
 part 'src/test_module.dart';
 
 main() {
-  group('injector -', () {
-    final myModule = new MyModule();
-    var injector = new Injector(myModule);
+    group('injector -', () {
+        final myModule = new MyModule();
+        var injector = new Injector(myModule);
 
-    test('inject singleton', () {
-      var instances = [injector.getInstance(MyClass), injector.getInstance(MyClass)];
-      expect(instances, everyElement(isNotNull));
-      expect(instances.first.getName(), equals('MyClass'));
-      expect(identical(instances[0], instances[1]), isTrue, reason:'must be singleton');
+        test('inject singleton', () {
+            var instances = [injector.getInstance(MyClass), injector.getInstance(MyClass)];
+            expect(instances, everyElement(isNotNull));
+            expect(instances.first.getName(), equals('MyClass'));
+            expect(identical(instances[0], instances[1]), isTrue, reason: 'must be singleton');
+        });
+
+        test('inject instance', () {
+            var instances = [injector.getInstance(MyOtherClass), injector.getInstance(MyOtherClass)];
+            expect(instances, everyElement(isNotNull));
+            expect(instances, everyElement(predicate((e) => e.getName() == 'MyOtherClass', '')));
+            expect(identical(instances[0], instances[1]), isFalse, reason: 'must be new instances');
+        });
+
+        test('inject function', () {
+            var func = injector.getInstance(MyFunction);
+            expect(func, isNotNull);
+            expect(func(), equals('MyFunction'));
+        });
+
+        test('inject function in class', () {
+            var func = injector.getInstance(MyClassFunction);
+            expect(func, isNotNull);
+            expect(func(), equals('MyClass'));
+        });
+
+        test('getInstance', () {
+            var instance = injector.getInstance(MyClassToInject);
+            expect(instance, isNotNull);
+            expect(instance, new isInstanceOf<MyClassToInject>());
+            expect((instance as MyClassToInject).assertInjections(), isTrue);
+        });
+
+        test('resolveInjections', () {
+            var instance = new MyClassToInject.inject(new MyClass());
+            expect((instance as MyClassToInject).assertInjections(), isFalse);
+            
+            var resolvedInstance = injector.resolveInjections(instance);
+
+            expect((resolvedInstance as MyClassToInject).assertInjections(), isTrue);
+            expect(identical(resolvedInstance, instance), isTrue);
+        });
+
+        test('named injections', () {
+            var myClass = injector.getInstance(MyClass);
+            var mySpecialClass = injector.getInstance(MyClass, "MySpecialClass");
+            expect(myClass is MyClass, isTrue);
+            expect(myClass is! MySpecialClass, isTrue);
+            expect(mySpecialClass is MyClass, isTrue);
+            expect(mySpecialClass is MySpecialClass, isTrue);
+        });
+
+        test('get registrations', () {
+            var registrations = injector.registrations;
+            expect(registrations, isNotNull);
+            expect(() => registrations[new TypeMirrorWrapper(reflectType(MyClass), null)] = new Registration(MyClass),
+                throwsUnsupportedError);
+        });
+
+        test('asSingleton', () {
+            final MySingletonClass singleton1 = injector.getInstance(MySingletonClass);
+            final MySingletonClass singleton2 = injector.getInstance(MySingletonClass);
+
+            expect(singleton1.instanceID, 1);
+            expect(singleton2.instanceID, 1);
+            expect(singleton1.hashCode,singleton2.hashCode);
+
+        }); // end of 'asSingleton' test
+
+        test('asSingleton II', () {
+            final singletonModule = new MySingletonModule();
+            var sInjector = new Injector(singletonModule);
+
+            var instances = [sInjector.getInstance(AnotherSingletonClass), sInjector.getInstance(AnotherSingletonClass)];
+            expect(instances, everyElement(isNotNull));
+            expect(instances.first.getName(), equals('AnotherSingletonClass'));
+            expect(identical(instances[0], instances[1]), isTrue, reason: 'must be singleton');
+            expect(instances[0].hashCode,instances[1].hashCode);
+
+        }); // end of 'asSingleton' test
+
+        test('MultiModule', () {
+            final myMultiModule = new MyModuleForInstallation();
+            var multiInjector = new Injector(myMultiModule);
+
+            final MySingletonClass singleton = multiInjector.getInstance(MySingletonClass);
+
+            // installed Module overwrites the definition of MySingletonClass
+            expect(singleton, new isInstanceOf<MySpecialSingletonClass2>());
+        }); // end of '' test
+
     });
 
-    test('inject instance', () {
-      var instances = [injector.getInstance(MyOtherClass), injector.getInstance(MyOtherClass)];
-      expect(instances, everyElement(isNotNull));
-      expect(instances, everyElement(predicate((e) => e.getName() == 'MyOtherClass', '')));
-      expect(identical(instances[0], instances[1]), isFalse, reason:'must be new instances');
+    group('modules - ', () {
+        final yourModule = new YourModule();
+        final myModule = new MyModule();
+
+        test('multiple modules', () {
+            var injector = new Injector.fromModules([myModule, yourModule]);
+
+            var myClass = injector.getInstance(MyClass);
+            var yourClass = injector.getInstance(YourClass);
+
+            expect(myClass, new isInstanceOf<MyClass>());
+            expect(yourClass, new isInstanceOf<YourClass>());
+        });
+
+        test('register runtime', () {
+            var injector = new Injector(myModule);
+            expect(() => injector.getInstance(YourClass), throwsArgumentError);
+
+            injector.register(YourClass).toType(YourClass);
+            expect(injector.getInstance(YourClass), new isInstanceOf<YourClass>());
+        });
+
+        test('unregister runtime', () {
+            var injector = new Injector();
+            injector
+                ..register(MyClass).toType(MySpecialClass)
+                ..register(YourClass)..register(MyOtherClass)
+                ..register(MyClass, 'test').toType(MySpecialClass);
+
+            var myClass = injector.getInstance(MyClass);
+            var yourClass = injector.getInstance(YourClass);
+            var myOtherClass = injector.getInstance(MyOtherClass);
+
+            expect(myClass, new isInstanceOf<MySpecialClass>());
+            expect(yourClass, new isInstanceOf<YourClass>());
+            expect(myOtherClass, new isInstanceOf<MyOtherClass>());
+
+            injector.unregister(MyClass);
+            injector.unregister(YourClass);
+            injector.unregister(MyOtherClass);
+
+            expect(() => injector.getInstance(MyClass), throwsArgumentError);
+            expect(() => injector.getInstance(YourClass), throwsArgumentError);
+            expect(() => injector.getInstance(MyOtherClass), throwsArgumentError);
+
+            var myNamedClass = injector.getInstance(MyClass, 'test');
+            expect(myNamedClass, new isInstanceOf<MySpecialClass>());
+        });
+
+        test('join injectors', () {
+            var injector1 = new Injector(myModule);
+            var injector2 = new Injector(yourModule);
+            var joinedInjector = new Injector.fromInjectors([injector1, injector2]);
+
+            var myClass = joinedInjector.getInstance(MyClass);
+            var yourClass = joinedInjector.getInstance(YourClass);
+
+            expect(myClass, new isInstanceOf<MyClass>());
+            expect(yourClass, new isInstanceOf<YourClass>());
+        });
     });
 
-    test('inject function', () {
-      var func = injector.getInstance(MyFunction);
-      expect(func, isNotNull);
-      expect(func(), equals('MyFunction'));
+    group('internals -', () {
+        var injector = new InjectorImpl(new MyModule());
+        var classMirror = reflectClass(MyClassToInject);
+
+        test('new instance of MyClass', () {
+            var instance = injector.getInstance(MyClass);
+            expect(instance, isNotNull);
+            expect(instance, new isInstanceOf<MyClass>());
+        });
+
+        test('new instance of MyClassToInject', () {
+            var instance = injector.getInstance(MyClassToInject);
+            expect(instance, isNotNull);
+            expect(instance, new isInstanceOf<MyClassToInject>());
+        });
+
+        test('constructors', () {
+            var constructors = injector.injectableConstructors(classMirror).toList().map((c) =>
+                symbolAsString(c.simpleName));
+            var expected = ['MyClassToInject.inject'];
+            expect(constructors, unorderedEquals(expected));
+        });
+
+        test('setters', () {
+            var setters = injector.injectableSetters(classMirror).toList().map((s) => symbolAsString(s.simpleName));
+            var expected = ['setterToInject=', '_setterToInject='];
+            expect(setters, unorderedEquals(expected));
+        });
+
+        test('variables', () {
+            var variables = injector.injectableVariables(classMirror).toList().map((v) => symbolAsString(v.simpleName));
+            var expected = ['variableToInject', '_variableToInject', 'namedVariableToInject', '_namedVariableToInject'];
+            expect(variables, unorderedEquals(expected));
+        });
     });
-
-    test('inject function in class', () {
-      var func = injector.getInstance(MyClassFunction);
-      expect(func, isNotNull);
-      expect(func(), equals('MyClass'));
-    });
-
-    test('getInstance', () {
-      var instance = injector.getInstance(MyClassToInject);
-      expect(instance, isNotNull);
-      expect(instance, new isInstanceOf<MyClassToInject>());
-      expect((instance as MyClassToInject).assertInjections(), isTrue);
-    });
-
-    test('resolveInjections', () {
-      var instance = new MyClassToInject.inject(new MyClass());
-      expect((instance as MyClassToInject).assertInjections(), isFalse);
-      var resolvedInstance = injector.resolveInjections(instance);
-
-      expect((resolvedInstance as MyClassToInject).assertInjections(), isTrue);
-      expect(identical(resolvedInstance, instance), isTrue);
-    });
-
-    test('named injections', () {
-      var myClass = injector.getInstance(MyClass);
-      var mySpecialClass = injector.getInstance(MyClass, "MySpecialClass");
-      expect(myClass is MyClass, isTrue);
-      expect(myClass is! MySpecialClass, isTrue);
-      expect(mySpecialClass is MyClass, isTrue);
-      expect(mySpecialClass is MySpecialClass, isTrue);
-    });
-
-    test('get registrations', () {
-      var registrations = injector.registrations;
-      expect(registrations, isNotNull);
-      expect(() => registrations[new TypeMirrorWrapper(reflectType(MyClass), null)] = new Registration(MyClass), throwsUnsupportedError);
-    });
-  });
-
-  group('modules - ', () {
-    final yourModule = new YourModule();
-    final myModule = new MyModule();
-
-    test('multiple modules', () {
-      var injector = new Injector.fromModules([myModule, yourModule]);
-
-      var myClass = injector.getInstance(MyClass);
-      var yourClass = injector.getInstance(YourClass);
-
-      expect(myClass, new isInstanceOf<MyClass>());
-      expect(yourClass, new isInstanceOf<YourClass>());
-    });
-
-    test('register runtime', () {
-      var injector = new Injector(myModule);
-      expect(() => injector.getInstance(YourClass), throwsArgumentError);
-
-      injector.register(YourClass).toType(YourClass);
-      expect(injector.getInstance(YourClass), new isInstanceOf<YourClass>());
-    });
-
-    test('unregister runtime', () {
-      var injector = new Injector();
-      injector
-        ..register(MyClass).toType(MySpecialClass)
-        ..register(YourClass)
-        ..register(MyOtherClass)
-        ..register(MyClass, 'test').toType(MySpecialClass);
-
-      var myClass = injector.getInstance(MyClass);
-      var yourClass = injector.getInstance(YourClass);
-      var myOtherClass = injector.getInstance(MyOtherClass);
-
-      expect(myClass, new isInstanceOf<MySpecialClass>());
-      expect(yourClass, new isInstanceOf<YourClass>());
-      expect(myOtherClass, new isInstanceOf<MyOtherClass>());
-
-      injector.unregister(MyClass);
-      injector.unregister(YourClass);
-      injector.unregister(MyOtherClass);
-
-      expect(() => injector.getInstance(MyClass), throwsArgumentError);
-      expect(() => injector.getInstance(YourClass), throwsArgumentError);
-      expect(() => injector.getInstance(MyOtherClass), throwsArgumentError);
-
-      var myNamedClass = injector.getInstance(MyClass, 'test');
-      expect(myNamedClass, new isInstanceOf<MySpecialClass>());
-    });
-
-    test('join injectors', () {
-      var injector1 = new Injector(myModule);
-      var injector2 = new Injector(yourModule);
-      var joinedInjector = new Injector.fromInjectors([injector1, injector2]);
-
-      var myClass = joinedInjector.getInstance(MyClass);
-      var yourClass = joinedInjector.getInstance(YourClass);
-
-      expect(myClass, new isInstanceOf<MyClass>());
-      expect(yourClass, new isInstanceOf<YourClass>());
-    });
-  });
-
-  group('internals -', () {
-    var injector = new InjectorImpl(new MyModule());
-    var classMirror = reflectClass(MyClassToInject);
-
-    test('new instance of MyClass', () {
-      var instance = injector.getInstance(MyClass);
-      expect(instance, isNotNull);
-      expect(instance, new isInstanceOf<MyClass>());
-    });
-
-    test('new instance of MyClassToInject', () {
-      var instance = injector.getInstance(MyClassToInject);
-      expect(instance, isNotNull);
-      expect(instance, new isInstanceOf<MyClassToInject>());
-    });
-
-    test('constructors', () {
-      var constructors = injector.injectableConstructors(classMirror).toList().map((c) => symbolAsString(c.simpleName));
-      var expected = ['MyClassToInject.inject'];
-      expect(constructors, unorderedEquals(expected));
-    });
-
-    test('setters', () {
-      var setters = injector.injectableSetters(classMirror).toList().map((s) => symbolAsString(s.simpleName));
-      var expected = ['setterToInject=', '_setterToInject='];
-      expect(setters, unorderedEquals(expected));
-    });
-
-    test('variables', () {
-      var variables = injector.injectableVariables(classMirror).toList().map((v) => symbolAsString(v.simpleName));
-      var expected = ['variableToInject', '_variableToInject', 'namedVariableToInject', '_namedVariableToInject'];
-      expect(variables, unorderedEquals(expected));
-    });
-  });
 }

--- a/test/src/test_module.dart
+++ b/test/src/test_module.dart
@@ -12,6 +12,9 @@ class MyModule extends Module {
     register(MyFunction).toFunction(MyFunctionToInject);
     register(MyClassFunction).toFunction(new MyClass().getName);
 
+    // Singleton
+    register(MySingletonClass).toType(MySpecialSingletonClass).asSingleton();
+
     // named
     register(MyClass, "MySpecialClass").toType(MySpecialClass);
   }
@@ -20,6 +23,23 @@ class MyModule extends Module {
 class YourModule extends Module {
   configure() {
     register(YourClass).toType(YourClass);
+  }
+}
+
+class MySingletonModule extends Module {
+    configure() {
+        // Singleton
+        register(AnotherSingletonClass).asSingleton();
+    }
+}
+
+class MyModuleForInstallation extends Module {
+
+  @override
+  configure() {
+    install(new MyModule());
+
+    register(MySingletonClass).toType(MySpecialSingletonClass2);
   }
 }
 
@@ -98,6 +118,31 @@ class MySpecialClass implements MyClass {
 
 class YourClass {
   String getName() => "YourClass";
+}
+
+class MySingletonClass {
+    static int instanceCounter = 1;
+
+    /// Remember the actual instance
+    final int instanceID;
+
+    MySingletonClass() : instanceID = instanceCounter {
+        instanceCounter++;
+    }
+
+    String getName() => "MySingletonClass - InstanceID: ${instanceID}";
+}
+
+class MySpecialSingletonClass extends MySingletonClass {
+    String getName() => "MySpecialSingletonClass - InstanceID: ${instanceID}";
+}
+
+class MySpecialSingletonClass2 extends MySingletonClass {
+    String getName() => "MySpecialSingletonClass2 - InstanceID: ${instanceID}";
+}
+
+class AnotherSingletonClass {
+    String getName() => "AnotherSingletonClass";
 }
 
 MyFunctionToInject() => "MyFunction";


### PR DESCRIPTION
Hi, made some changes - hope you'll accept them:

Registration#asSingleton - makes it possible to register a class as Singleton
I know there is `toInstance` but it's not always possible to create an instance in configure()
I use `asSingleton` e.g. for registering the Application-Component for my MDL-Lib:
https://github.com/MikeMitterer/dart-material-design-lite/blob/move_to_dice/lib/src/core/MdlComponentHandler.dart#L29-#L38

Modul#install
With this it's not necessary to know all the Modules in the Module-Tree. You have to know only the next module in the Module-Tree

Tests are included.
