### PR TITLE
metaTarget added for JS/Chrome injections, test split into chrome/non…

### DIFF
--- a/lib/dice.dart
+++ b/lib/dice.dart
@@ -5,7 +5,9 @@
 /** Lightweight dependency injection framework for Dart. */
 library dice;
 
-@MirrorsUsed(symbols: const ['inject', 'Named'])
+@MirrorsUsed(
+    metaTargets: const [ Inject ],
+    symbols: const ['inject', 'Named'])
 import 'dart:mirrors';
 import 'dart:collection';
 

--- a/lib/dice.dart
+++ b/lib/dice.dart
@@ -6,10 +6,12 @@
 library dice;
 
 @MirrorsUsed(
-    metaTargets: const [ Inject ],
-    symbols: const ['inject', 'Named'])
+    metaTargets: const [ Inject, Injectable ],
+    symbols: const ['inject', 'injectable', 'Named'])
 import 'dart:mirrors';
 import 'dart:collection';
+
+import 'package:logging/logging.dart';
 
 part 'src/annotations.dart';
 part 'src/Registration.dart';

--- a/lib/src/annotations.dart
+++ b/lib/src/annotations.dart
@@ -4,13 +4,19 @@
 
 part of dice;
 
-/** Used to annotate constructors, methods and fields of your classes where [Injector] should resolve values */
+/// Used to annotate constructors, methods and fields of your classes where [Injector] should resolve values
 const inject = const Inject();
 class Inject {
   const Inject();
 }
 
-/** Used in conjunction with [Inject] to select a specific named target for injection */
+/// Compatibility to di-package
+const injectable = const Injectable();
+class Injectable {
+    const Injectable();
+}
+
+/// Used in conjunction with [Inject] to select a specific named target for injection
 class Named {
   const Named(this.name);
 

--- a/lib/src/injector.dart
+++ b/lib/src/injector.dart
@@ -43,17 +43,17 @@ abstract class Injector {
     }
 
     /// register a [type] with [named] (optional) to an implementation
-    Registration register(Type type, { final String named = null, final Type annotatedWidth: null });
+    Registration register(Type type, { final String named = null, final Type annotatedWith: null });
 
     /// Compatibility with di:package
-    Registration bind(Type type,  { final String named = null, final Type annotatedWidth: null })
-        => register(type,named: named, annotatedWidth: annotatedWidth);
+    Registration bind(Type type,  { final String named = null, final Type annotatedWith: null })
+        => register(type,named: named, annotatedWith: annotatedWith);
 
     /** unregister a [type] and [named] (optional), returns [true] if registration has been removed*/
-    bool unregister(Type type, { final String named: null, final Type annotatedWidth: null });
+    bool unregister(Type type, { final String named: null, final Type annotatedWith: null });
 
     /** Get new instance of [type] with [named] (optional) and all dependencies resolved */
-    dynamic getInstance(Type type, { final String named: null, final Type annotatedWidth: null });
+    dynamic getInstance(Type type, { final String named: null, final Type annotatedWith: null });
 
     /** Resolve injections in existing Object (does not create a new instance) */
     Object resolveInjections(Object obj);
@@ -78,16 +78,16 @@ class InjectorImpl extends Injector {
     }
 
     @override
-    Registration register(Type type, { final String named: null, final Type annotatedWidth: null }) {
+    Registration register(Type type, { final String named: null, final Type annotatedWith: null }) {
         var registration = new Registration(type);
-        var typeMirrorWrapper = new TypeMirrorWrapper.fromType(type, named, annotatedWidth);
+        var typeMirrorWrapper = new TypeMirrorWrapper.fromType(type, named, annotatedWith);
         _registrations[typeMirrorWrapper] = registration;
         return registration;
     }
 
     @override
-    bool unregister(Type type, { final String named: null, final Type annotatedWidth: null }) {
-        return _removeRegistrationFor(reflectType(type), named, annotatedWidth != null ? reflectType(type) : null) !=
+    bool unregister(Type type, { final String named: null, final Type annotatedWith: null }) {
+        return _removeRegistrationFor(reflectType(type), named, annotatedWith != null ? reflectType(type) : null) !=
             null;
     }
 
@@ -106,9 +106,9 @@ class InjectorImpl extends Injector {
     }
 
     @override
-    dynamic getInstance(Type type, { final String named: null, final Type annotatedWidth: null }) {
+    dynamic getInstance(Type type, { final String named: null, final Type annotatedWith: null }) {
         var typeMirror = reflectType(type);
-        return _getInstanceFor(typeMirror, named, annotatedWidth);
+        return _getInstanceFor(typeMirror, named, annotatedWith);
     }
 
     @override
@@ -120,13 +120,13 @@ class InjectorImpl extends Injector {
     @override
     Map<TypeMirrorWrapper, Registration> get registrations => new UnmodifiableMapView(_registrations);
 
-    dynamic _getInstanceFor(TypeMirror tm, [ final String named = null, final Type annotatedWidth = null ]) {
-        final annotationTypeMirror = annotatedWidth != null ? reflectType(annotatedWidth) : null;
+    dynamic _getInstanceFor(TypeMirror tm, [ final String named = null, final Type annotatedWith = null ]) {
+        final annotationTypeMirror = annotatedWith != null ? reflectType(annotatedWith) : null;
         if (!_hasRegistrationFor(tm, named, annotationTypeMirror)) {
             throw new ArgumentError(
                 "no instance registered for type ${symbolAsString(tm.simpleName)}, "
                     "named: $named, "
-                    "annotatedWith: $annotatedWidth");
+                    "annotatedWith: $annotatedWith");
         }
 
         var registration = _getRegistrationFor(tm, named, annotationTypeMirror);

--- a/lib/src/injector.dart
+++ b/lib/src/injector.dart
@@ -45,8 +45,9 @@ abstract class Injector {
     /// register a [type] with [named] (optional) to an implementation
     Registration register(Type type, { final String named = null, final Type annotatedWidth: null });
 
-    // Compatibility with di:package
-    //Registration bind(Type type, [String name]) => register(type,name);
+    /// Compatibility with di:package
+    Registration bind(Type type,  { final String named = null, final Type annotatedWidth: null })
+        => register(type,named: named, annotatedWidth: annotatedWidth);
 
     /** unregister a [type] and [named] (optional), returns [true] if registration has been removed*/
     bool unregister(Type type, { final String named: null, final Type annotatedWidth: null });
@@ -59,15 +60,17 @@ abstract class Injector {
 
     /** Get unmodifiable map of registrations */
     Map<TypeMirrorWrapper, Registration> get registrations;
+
+    Injector._private();
 }
 
 /// Implementation of [Injector].
-class InjectorImpl implements Injector {
+class InjectorImpl extends Injector {
     final Logger _logger = new Logger('dice.InjectorImpl');
 
     final Map<TypeMirrorWrapper, Registration> _registrations = new Map<TypeMirrorWrapper, Registration>();
 
-    InjectorImpl([module = null]) {
+    InjectorImpl([module = null]) : super._private() {
         if (module != null) {
             module.configure();
             _registrations.addAll(module._registrations);

--- a/lib/src/injector.dart
+++ b/lib/src/injector.dart
@@ -4,232 +4,265 @@
 
 part of dice;
 
-/** Resolve types to their implementing classes */
+/// Resolve types to their implementing classes
 abstract class Injector {
-  factory Injector([Module module = null]) => new InjectorImpl(module);
+    factory Injector([Module module = null]) => new InjectorImpl(module);
 
-  factory Injector.fromModules(List<Module> modules) => new InjectorImpl(new _ModuleContainer(modules));
+    factory Injector.fromModules(List<Module> modules) => new InjectorImpl(new _ModuleContainer(modules));
 
-  factory Injector.fromInjectors(List<Injector> injectors) {
-    var injector = new InjectorImpl();
-    injectors.forEach((ijtor) =>
-      ijtor.registrations.forEach((typeMirrorWrapper, registration) {
-      if(!injector._registrations.containsKey(typeMirrorWrapper)) {
-        injector._registrations[typeMirrorWrapper] = registration;
-      }
-    })
-    );
-    return injector;
-  }
+    factory Injector.fromInjectors(List<Injector> injectors) {
+        var injector = new InjectorImpl();
+        injectors.forEach((ijtor) =>
+            ijtor.registrations.forEach((typeMirrorWrapper, registration) {
+                if (!injector._registrations.containsKey(typeMirrorWrapper)) {
+                    injector._registrations[typeMirrorWrapper] = registration;
+                }
+            })
+        );
+        return injector;
+    }
 
-  /** register a [type] with [name] (optional) to an implementation */
-  Registration register(Type type, [String name]);
+    /// register a [type] with [named] (optional) to an implementation
+    Registration register(Type type, { final String named = null, final Type annotatedWidth: null });
 
-  /** unregister a [type] and [name] (optional), returns [true] if registration has been removed*/
-  bool unregister(Type type, [String name]);
+    // Compatibility with di:package
+    //Registration bind(Type type, [String name]) => register(type,name);
 
-  /** Get new instance of [type] with [name] (optional) and all dependencies resolved */
-  dynamic getInstance(Type type, [String name]);
+    /** unregister a [type] and [named] (optional), returns [true] if registration has been removed*/
+    bool unregister(Type type, { final String named: null, final Type annotatedWidth: null });
 
-  /** Resolve injections in existing Object (does not create a new instance) */
-  Object resolveInjections(Object obj);
+    /** Get new instance of [type] with [named] (optional) and all dependencies resolved */
+    dynamic getInstance(Type type, { final String named: null, final Type annotatedWidth: null });
 
-  /** Get unmodifiable map of registrations */
-  Map<TypeMirrorWrapper, Registration> get registrations;
+    /** Resolve injections in existing Object (does not create a new instance) */
+    Object resolveInjections(Object obj);
+
+    /** Get unmodifiable map of registrations */
+    Map<TypeMirrorWrapper, Registration> get registrations;
 }
 
 /** Implementation of [Injector]. */
 class InjectorImpl implements Injector {
-  final Map<TypeMirrorWrapper, Registration> _registrations = new Map<TypeMirrorWrapper, Registration>();
+    final Logger _logger = new Logger('dice.InjectorImpl');
 
-  InjectorImpl([module = null]) {
-    if (module != null) {
-      module.configure();
-      _registrations.addAll(module._registrations);
-    }
-  }
+    final Map<TypeMirrorWrapper, Registration> _registrations = new Map<TypeMirrorWrapper, Registration>();
 
-  @override
-  Registration register(Type type, [String name = null]) {
-    var registration = new Registration(type);
-    var typeMirrorWrapper = new TypeMirrorWrapper.fromType(type, name);
-    _registrations[typeMirrorWrapper] = registration;
-    return registration;
-  }
-
-  @override
-  bool unregister(Type type, [String name = null]) {
-    return _removeRegistrationFor(reflectType(type), name) != null;
-  }
-
-  bool _hasRegistrationFor(TypeMirror type, String name) => _registrations.containsKey(new TypeMirrorWrapper(type, name));
-
-  Registration _getRegistrationFor(TypeMirror type, String name) => _registrations[new TypeMirrorWrapper(type, name)];
-
-  Registration _removeRegistrationFor(TypeMirror type, String name) {
-      final Registration registration = _registrations.remove(new TypeMirrorWrapper(type, name));
-
-      // Remove reference to our instance if there is one
-      registration._instance = null;
-      return registration;
-  }
-
-  @override
-  dynamic getInstance(Type type, [String name = null]) {
-    var typeMirror = reflectType(type);
-    return _getInstanceFor(typeMirror, name);
-  }
-
-  @override
-  Object resolveInjections(Object obj) {
-    var instanceMirror = reflect(obj);
-    return _resolveInjections(instanceMirror);
-  }
-
-  @override
-  Map<TypeMirrorWrapper, Registration> get registrations => new UnmodifiableMapView(_registrations);
-
-  dynamic _getInstanceFor(TypeMirror tm, [String name = null]) {
-    if(!_hasRegistrationFor(tm, name)) {
-      throw new ArgumentError("no instance registered for type ${symbolAsString(tm.simpleName)}");
+    InjectorImpl([module = null]) {
+        if (module != null) {
+            module.configure();
+            _registrations.addAll(module._registrations);
+        }
     }
 
-    var registration = _getRegistrationFor(tm, name);
-
-    // Check if we want a singleton
-    if(registration._asSingleton && registration._instance != null) {
-        // If we have one - return it
-        print("If we have one - return it");
-        return registration._instance;
+    @override
+    Registration register(Type type, { final String named: null, final Type annotatedWidth: null }) {
+        var registration = new Registration(type);
+        var typeMirrorWrapper = new TypeMirrorWrapper.fromType(type, named, annotatedWidth);
+        _registrations[typeMirrorWrapper] = registration;
+        return registration;
     }
 
-    var obj = registration._builder();
-
-    InstanceMirror im = (obj is Type) ? _newInstance(reflectClass(obj)) : reflect(obj);
-    final instance = _resolveInjections(im);
-
-    if(registration._asSingleton) {
-        // Remember the instance
-        print("Remember the instance");
-        registration._instance = instance;
+    @override
+    bool unregister(Type type, { final String named: null, final Type annotatedWidth: null }) {
+        return _removeRegistrationFor(reflectType(type), named, annotatedWidth != null ? reflectType(type) : null) !=
+            null;
     }
-    return instance;
-  }
 
-  dynamic _resolveInjections(InstanceMirror im) {
-    im = _injectSetters(im);
-    im = _injectVariables(im);
-    return im.reflectee;
-  }
+    bool _hasRegistrationFor(TypeMirror type, String name, TypeMirror annotation) =>
+        _registrations.containsKey(new TypeMirrorWrapper(type, name, annotation));
 
-  // create a new instance of classMirror and inject it
-  InstanceMirror _newInstance(ClassMirror classMirror) {
-    // Look for an injectable constructor
-    var constructors = injectableConstructors(classMirror).toList();
-    // that has the greatest number of parameters to inject, optional included
-    MethodMirror constructor = constructors.fold(null, (MethodMirror p, MethodMirror e) =>
-            p == null || _injectableParameters(p).length < _injectableParameters(e).length ? e : p);
-    var constructorArgs = constructor.parameters.map((pm) => _getInstanceFor(pm.type)).toList();
+    Registration _getRegistrationFor(TypeMirror type, String name, TypeMirror annotation) =>
+        _registrations[new TypeMirrorWrapper(type, name, annotation)];
 
-    return classMirror.newInstance(constructor.constructorName, constructorArgs);
-  }
+    Registration _removeRegistrationFor(TypeMirror type, String name, TypeMirror annotation) {
+        final Registration registration = _registrations.remove(new TypeMirrorWrapper(type, name, annotation));
 
-  InstanceMirror _injectSetters(InstanceMirror instanceMirror) {
-    var setters = injectableSetters(instanceMirror.type);
-    setters.forEach((setter) {
-      var instanceToInject = _getInstanceFor(_firstParameter(setter));
-      // set the resolved injection on the instance mirror we are injecting into
-      instanceMirror.setField(_methodName(setter), instanceToInject);
-    });
-    return instanceMirror;
-  }
-
-  InstanceMirror _injectVariables(InstanceMirror instanceMirror) {
-    var variables = injectableVariables(instanceMirror.type);
-    variables.forEach((variable) {
-      var instanceToInject = _getInstanceFor(variable.type, _injectionName(variable));
-      // set the resolved injection on the instance mirror we are injecting into
-      instanceMirror.setField(variable.simpleName, instanceToInject);
-    });
-    return instanceMirror;
-  }
-
-  /** Returns setters that can be injected */
-  Iterable<DeclarationMirror> injectableSetters(ClassMirror classMirror) {
-    return injectableDeclarations(classMirror).where(_isSetter);
-  }
-
-  /** Returns variables that can be injected */
-  Iterable<DeclarationMirror> injectableVariables(ClassMirror classMirror) {
-    return injectableDeclarations(classMirror).where(_isVariable);
-  }
-
-  /** Returns constructors that can be injected */
-  Iterable<DeclarationMirror> injectableConstructors(ClassMirror classMirror) {
-    var constructors = injectableDeclarations(classMirror).where(_isConstructor);
-    if(constructors.isEmpty) {
-      // no explict injectable constructor exists use the default constructor instead
-      constructors = classMirror.declarations.values.where((DeclarationMirror m) => _isConstructor(m) && (m as MethodMirror).parameters.isEmpty);
-      if(constructors.isEmpty) {
-        throw new StateError("no injectable constructors exists for ${classMirror}");
-      }
+        // Remove reference to our instance if there is one
+        registration._instance = null;
+        return registration;
     }
-    return constructors;
-  }
 
-  /** Returns injectable instance members such as variables, setters, constructors that need injection */
-  Iterable<DeclarationMirror> injectableDeclarations(ClassMirror classMirror) =>
-      classMirror.declarations.values.where(_isInjectable);
-
-  /** Returns true if [mirror] is annotated with [Inject] */
-  bool _isInjectable(DeclarationMirror mirror) {
-      return mirror.metadata.any((final InstanceMirror im) {
-          return im.reflectee is Inject;
-      });
-  }
-
-  /** Returns true if [declaration] is a constructor */
-  bool _isConstructor(DeclarationMirror declaration) => declaration is MethodMirror && declaration.isConstructor;
-
-  /** Returns true if [declaration] is a variable */
-  bool _isVariable(DeclarationMirror declaration) => declaration is VariableMirror;
-
-  /** Returns true if [declaration] is a setter */
-  bool _isSetter(DeclarationMirror declaration) => declaration is MethodMirror && declaration.isSetter;
-
-  /** Returns name of injection or null if it's unamed */
-  String _injectionName(DeclarationMirror declaration) {
-    var namedMirror = _namedAnnotationOf(declaration);
-    if(namedMirror == null) {
-      return null;
+    @override
+    dynamic getInstance(Type type, { final String named: null, final Type annotatedWidth: null }) {
+        var typeMirror = reflectType(type);
+        return _getInstanceFor(typeMirror, named, annotatedWidth);
     }
-    return namedMirror.name;
-  }
 
-  /** Get [Named] annotation for [declaration]. Returns null is non exists */
-  Named _namedAnnotationOf(DeclarationMirror declaration) {
-    var namedMirror = declaration.metadata.firstWhere((InstanceMirror im) => im.reflectee is Named, orElse: () => null);
-    if(namedMirror != null) {
-      return (namedMirror.reflectee as Named);
+    @override
+    Object resolveInjections(Object obj) {
+        var instanceMirror = reflect(obj);
+        return _resolveInjections(instanceMirror);
     }
-    return null;
-  }
 
-  /** Returns method name from [MethodMirror] */
-  Symbol _methodName(MethodMirror method) {
-    var name = symbolAsString(method.simpleName);
-    var symbolName = (name[0] == "_") ? name.substring(1, name.length - 1) : name.substring(0, name.length - 1);
-    // TODO fix print("name $name symbol $symbolName");
-    return stringAsSymbol(symbolName);
-  }
+    @override
+    Map<TypeMirrorWrapper, Registration> get registrations => new UnmodifiableMapView(_registrations);
 
-  /** Returns [TypeMirror] for first parameter in method */
-  TypeMirror _firstParameter(MethodMirror method) =>
-      method.parameters[0].type;
+    dynamic _getInstanceFor(TypeMirror tm, [ final String named = null, final Type annotatedWidth = null ]) {
+        final annotationTypeMirror = annotatedWidth != null ? reflectType(annotatedWidth) : null;
+        if (!_hasRegistrationFor(tm, named, annotationTypeMirror)) {
+            throw new ArgumentError(
+                "no instance registered for type ${symbolAsString(tm.simpleName)}, "
+                    "named: $named, "
+                    "annotatedWith: $annotatedWidth");
+        }
 
-  /** Returns parameters (including optional) that can be injected */
-  Iterable<ParameterMirror> _injectableParameters(MethodMirror method) =>
-      // TODO support named parameters
-      method.parameters.where((pm) => _hasRegistrationFor(pm.type, null));
+        var registration = _getRegistrationFor(tm, named, annotationTypeMirror);
+
+        // Check if we want a singleton
+        if (registration._asSingleton && registration._instance != null) {
+            // If we have one - return it
+            return registration._instance;
+        }
+
+        var obj = registration._builder();
+
+        InstanceMirror im = (obj is Type) ? _newInstance(reflectClass(obj)) : reflect(obj);
+        final instance = _resolveInjections(im);
+
+        if (registration._asSingleton) {
+            // Remember the instance
+            registration._instance = instance;
+        }
+        return instance;
+    }
+
+    dynamic _resolveInjections(InstanceMirror im) {
+        im = _injectSetters(im);
+        im = _injectVariables(im);
+        return im.reflectee;
+    }
+
+    /// create a new instance of classMirror and inject it
+    InstanceMirror _newInstance(ClassMirror classMirror) {
+        // Look for an injectable constructor
+        var constructors = injectableConstructors(classMirror).toList();
+
+        // that has the greatest number of parameters to inject, optional included
+        MethodMirror constructor = constructors.fold(null, (MethodMirror p, MethodMirror e) =>
+        p == null || _injectableParameters(p).length < _injectableParameters(e).length ? e : p);
+
+        var constructorArgs = constructor.parameters.map((pm) => _getInstanceFor(pm.type)).toList();
+
+        return classMirror.newInstance(constructor.constructorName, constructorArgs);
+    }
+
+    InstanceMirror _injectSetters(InstanceMirror instanceMirror) {
+        var setters = injectableSetters(instanceMirror.type);
+        setters.forEach((setter) {
+            var instanceToInject = _getInstanceFor(_firstParameter(setter));
+            // set the resolved injection on the instance mirror we are injecting into
+            instanceMirror.setField(_methodName(setter), instanceToInject);
+        });
+        return instanceMirror;
+    }
+
+    InstanceMirror _injectVariables(InstanceMirror instanceMirror) {
+        var variables = injectableVariables(instanceMirror.type);
+        variables.forEach((variable) {
+            // typed-Annotation has priority - if we have one ignore a named-Annotation
+            final InstanceMirror typedAnnotation = _injectionType(variable);
+            final Type type = typedAnnotation != null ? typedAnnotation.reflectee.runtimeType : null;
+
+            // Only if we have no typed-Annotation
+            final String namedAnnotation = typedAnnotation == null ? _injectionName(variable) : null;
+
+            final instanceToInject = _getInstanceFor(variable.type, namedAnnotation, type);
+
+            // set the resolved injection on the instance mirror we are injecting into
+            instanceMirror.setField(variable.simpleName, instanceToInject);
+        });
+        return instanceMirror;
+    }
+
+    /** Returns setters that can be injected */
+    Iterable<DeclarationMirror> injectableSetters(ClassMirror classMirror) {
+        return injectableDeclarations(classMirror).where(_isSetter);
+    }
+
+    /** Returns variables that can be injected */
+    Iterable<DeclarationMirror> injectableVariables(ClassMirror classMirror) {
+        return injectableDeclarations(classMirror).where(_isVariable);
+    }
+
+    /** Returns constructors that can be injected */
+    Iterable<DeclarationMirror> injectableConstructors(ClassMirror classMirror) {
+        var constructors = injectableDeclarations(classMirror).where(_isConstructor);
+        if (constructors.isEmpty) {
+            // no explict injectable constructor exists use the default constructor instead
+            constructors = classMirror.declarations.values.where((DeclarationMirror m) =>
+            _isConstructor(m) &&
+                (m as MethodMirror).parameters.isEmpty);
+            if (constructors.isEmpty) {
+                throw new StateError("no injectable constructors exists for ${classMirror}");
+            }
+        }
+        return constructors;
+    }
+
+    /** Returns injectable instance members such as variables, setters, constructors that need injection */
+    Iterable<DeclarationMirror> injectableDeclarations(ClassMirror classMirror) =>
+        classMirror.declarations.values.where(_isInjectable);
+
+    /** Returns true if [mirror] is annotated with [Inject] */
+    bool _isInjectable(DeclarationMirror mirror) {
+        return mirror.metadata.any((final InstanceMirror im) {
+            return im.reflectee is Inject;
+        });
+    }
+
+    /** Returns true if [declaration] is a constructor */
+    bool _isConstructor(DeclarationMirror declaration) => declaration is MethodMirror && declaration.isConstructor;
+
+    /** Returns true if [declaration] is a variable */
+    bool _isVariable(DeclarationMirror declaration) => declaration is VariableMirror;
+
+    /** Returns true if [declaration] is a setter */
+    bool _isSetter(DeclarationMirror declaration) => declaration is MethodMirror && declaration.isSetter;
+
+    /** Returns name of injection or null if it's unamed */
+    String _injectionName(DeclarationMirror declaration) {
+        var namedMirror = _namedAnnotationOf(declaration);
+        if (namedMirror == null) {
+            return null;
+        }
+        return namedMirror.name;
+    }
+
+    /// Returns the first annotation after @inject or null if it's unannotated
+    InstanceMirror _injectionType(final DeclarationMirror declaration) {
+        return declaration.metadata.firstWhere((final InstanceMirror im) {
+            //print("T ${im.reflectee}");
+            return (im.reflectee is! Inject &&
+                im.reflectee is! Named &&
+                im.reflectee is! Injectable);
+        }, orElse: () => null);
+    }
+
+    /** Get [Named] annotation for [declaration]. Returns null is non exists */
+    Named _namedAnnotationOf(DeclarationMirror declaration) {
+        var namedMirror = declaration.metadata.firstWhere((InstanceMirror im) => im.reflectee is Named,
+            orElse: () => null);
+        if (namedMirror != null) {
+            return (namedMirror.reflectee as Named);
+        }
+        return null;
+    }
+
+    /** Returns method name from [MethodMirror] */
+    Symbol _methodName(MethodMirror method) {
+        var name = symbolAsString(method.simpleName);
+        var symbolName = (name[0] == "_") ? name.substring(1, name.length - 1) : name.substring(0, name.length - 1);
+        // TODO fix print("name $name symbol $symbolName");
+        return stringAsSymbol(symbolName);
+    }
+
+    /** Returns [TypeMirror] for first parameter in method */
+    TypeMirror _firstParameter(MethodMirror method) =>
+        method.parameters[0].type;
+
+    /** Returns parameters (including optional) that can be injected */
+    Iterable<ParameterMirror> _injectableParameters(MethodMirror method) =>
+        // TODO support named parameters
+    method.parameters.where((pm) => _hasRegistrationFor(pm.type, null, null));
 
 }

--- a/lib/src/mirror_util.dart
+++ b/lib/src/mirror_util.dart
@@ -4,20 +4,28 @@
 
 part of dice;
 
-/** Wrapper for [TypeMirror] to support multiple named registration for the same [Type] */
+/// Wrapper for [TypeMirror] to support multiple named registration for the same [Type] */
 class TypeMirrorWrapper {
-  final TypeMirror typeMirror;
-  final String name;
+    final TypeMirror typeMirror;
 
-  TypeMirrorWrapper(this.typeMirror, this.name);
+    final String name;
+    final TypeMirror annotationTypeMirror;
 
-  TypeMirrorWrapper.fromType(Type type, this.name) : typeMirror = reflectType(type);
+    TypeMirrorWrapper(this.typeMirror, this.name, this.annotationTypeMirror);
 
-  String get qualifiedName => symbolAsString(typeMirror.qualifiedName) + (name != null ? name : "");
+    TypeMirrorWrapper.fromType(final Type type, this.name, final Type annotation)
+        : typeMirror = reflectType(type),
+            annotationTypeMirror = annotation != null ? reflectType(annotation) : null;
 
-  get hashCode => qualifiedName.hashCode;
+    String get qualifiedName =>
+        symbolAsString(typeMirror.qualifiedName)
+            + (name != null ? "#$name" : "")
+            + (annotationTypeMirror != null
+                ? "#${symbolAsString(annotationTypeMirror.qualifiedName)}" : "");
 
-  bool operator ==(TypeMirrorWrapper other) => this.qualifiedName == other.qualifiedName;
+    get hashCode => qualifiedName.hashCode;
+
+    bool operator ==(TypeMirrorWrapper other) => this.qualifiedName == other.qualifiedName;
 }
 
 // helpers

--- a/lib/src/module.dart
+++ b/lib/src/module.dart
@@ -9,9 +9,9 @@ abstract class Module {
     final Logger _logger = new Logger('dice.Module');
 
     /// register a [type] with [named] (optional) to an implementation
-    Registration register(Type type, { final String named: null, final Type annotatedWidth: null }) {
+    Registration register(Type type, { final String named: null, final Type annotatedWith: null }) {
         final registration = new Registration(type);
-        final typeMirrorWrapper = new TypeMirrorWrapper.fromType(type, named, annotatedWidth);
+        final typeMirrorWrapper = new TypeMirrorWrapper.fromType(type, named, annotatedWith);
 
         _logger.fine("Register: ${typeMirrorWrapper.qualifiedName}");
         _registrations[typeMirrorWrapper] = registration;
@@ -19,8 +19,8 @@ abstract class Module {
     }
 
     /// Compatibility with di:package
-    Registration bind(final Type type, { final String named: null, final Type annotatedWidth: null }) =>
-        register(type, named: named, annotatedWidth: annotatedWidth);
+    Registration bind(final Type type, { final String named: null, final Type annotatedWith: null }) =>
+        register(type, named: named, annotatedWith: annotatedWith);
 
     /// Configure type/instance registrations used in this module
     configure();

--- a/lib/src/module.dart
+++ b/lib/src/module.dart
@@ -8,7 +8,7 @@ part of dice;
 abstract class Module {
     final Logger _logger = new Logger('dice.Module');
 
-    ///  register a [type] with [named] (optional) to an implementation
+    /// register a [type] with [named] (optional) to an implementation
     Registration register(Type type, { final String named: null, final Type annotatedWidth: null }) {
         final registration = new Registration(type);
         final typeMirrorWrapper = new TypeMirrorWrapper.fromType(type, named, annotatedWidth);
@@ -17,6 +17,10 @@ abstract class Module {
         _registrations[typeMirrorWrapper] = registration;
         return registration;
     }
+
+    /// Compatibility with di:package
+    Registration bind(final Type type, { final String named: null, final Type annotatedWidth: null }) =>
+        register(type, named: named, annotatedWidth: annotatedWidth);
 
     /// Configure type/instance registrations used in this module
     configure();

--- a/lib/src/module.dart
+++ b/lib/src/module.dart
@@ -6,11 +6,14 @@ part of dice;
 
 /// Associates types with their concrete instances returned by the [Injector]
 abstract class Module {
-    
-    ///  register a [type] with [name] (optional) to an implementation
-    Registration register(Type type, [String name = null]) {
-        var registration = new Registration(type);
-        var typeMirrorWrapper = new TypeMirrorWrapper.fromType(type, name);
+    final Logger _logger = new Logger('dice.Module');
+
+    ///  register a [type] with [named] (optional) to an implementation
+    Registration register(Type type, { final String named: null, final Type annotatedWidth: null }) {
+        final registration = new Registration(type);
+        final typeMirrorWrapper = new TypeMirrorWrapper.fromType(type, named, annotatedWidth);
+
+        _logger.fine("Register: ${typeMirrorWrapper.qualifiedName}");
         _registrations[typeMirrorWrapper] = registration;
         return registration;
     }
@@ -25,10 +28,11 @@ abstract class Module {
         _registrations.addAll(module._registrations);
     }
 
-    bool _hasRegistrationFor(TypeMirror type, String name) =>
-        _registrations.containsKey(new TypeMirrorWrapper(type, name));
+    bool _hasRegistrationFor(TypeMirror type, String name, TypeMirror annotation) =>
+        _registrations.containsKey(new TypeMirrorWrapper(type, name, annotation));
 
-    Registration _getRegistrationFor(TypeMirror type, String name) => _registrations[new TypeMirrorWrapper(type, name)];
+    Registration _getRegistrationFor(TypeMirror type, String name, TypeMirror annotation) =>
+        _registrations[new TypeMirrorWrapper(type, name, annotation)];
 
     final Map<TypeMirrorWrapper, Registration> _registrations = new Map<TypeMirrorWrapper, Registration>();
 }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -3,8 +3,12 @@ version: 1.6.5
 author: Lars Tackmann <lars@solvr.io>
 description: Lightweight dependency injection framework for Dart.
 homepage: https://github.com/ltackmann/dice
+
 environment:
   sdk: '>=1.9.0 <2.0.0'
+
 dependencies:
+
 dev_dependencies:
+  browser: ^0.10.0
   test: any

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -8,7 +8,12 @@ environment:
   sdk: '>=1.9.0 <2.0.0'
 
 dependencies:
+  logging: ^0.11.0
 
 dev_dependencies:
   browser: ^0.10.0
+
+  logging_handlers: ^0.8.0
+  console_log_handler: ^0.2.0
+
   test: any

--- a/test/config.dart
+++ b/test/config.dart
@@ -1,0 +1,33 @@
+/*
+ * Copyright (c) 2015, Michael Mitterer (office@mikemitterer.at),
+ * IT-Consulting and Development Limited.
+ * 
+ * All Rights Reserved.
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+     
+library dice.test.config;
+
+import 'package:logging/logging.dart';
+import 'package:logging_handlers/logging_handlers_shared.dart';
+
+void configLogging({final Level defaultLogLevel: Level.OFF }) {
+    //hierarchicalLoggingEnabled = false; // set this to true - its part of Logging SDK
+
+    // now control the logging.
+    // Turn off all logging first
+    Logger.root.level = defaultLogLevel;
+    Logger.root.onRecord.listen(new LogPrintHandler());
+}
+

--- a/test/config.dart
+++ b/test/config.dart
@@ -22,7 +22,7 @@ library dice.test.config;
 import 'package:logging/logging.dart';
 import 'package:logging_handlers/logging_handlers_shared.dart';
 
-void configLogging({final Level defaultLogLevel: Level.OFF }) {
+void configLogging({final Level defaultLogLevel: Level.INFO }) {
     //hierarchicalLoggingEnabled = false; // set this to true - its part of Logging SDK
 
     // now control the logging.

--- a/test/dice_test.dart
+++ b/test/dice_test.dart
@@ -1,9 +1,13 @@
 // Copyright (c) 2013, the project authors. Please see the AUTHORS file
 // for details. All rights reserved. Use of this source code is governed
 // by a Apache license that can be found in the LICENSE file.
+//@TestOn("chrome")
 
 library dice_test;
 
+@MirrorsUsed(
+    metaTargets: const [ Inject ],
+    symbols: const ['inject', 'Named'])
 import 'dart:mirrors';
 
 import 'package:test/test.dart';
@@ -15,6 +19,13 @@ main() {
     group('injector -', () {
         final myModule = new MyModule();
         var injector = new Injector(myModule);
+
+        test('> Simple', () {
+            final MyClassToInject obj = injector.getInstance(MyClassToInject);
+
+            expect(obj, isNotNull);
+            expect(obj, new isInstanceOf<MyClassToInject>());
+        }); // end of 'Simple' test
 
         test('inject singleton', () {
             var instances = [injector.getInstance(MyClass), injector.getInstance(MyClass)];
@@ -30,17 +41,17 @@ main() {
             expect(identical(instances[0], instances[1]), isFalse, reason: 'must be new instances');
         });
 
-        test('inject function', () {
-            var func = injector.getInstance(MyFunction);
-            expect(func, isNotNull);
-            expect(func(), equals('MyFunction'));
-        });
-
-        test('inject function in class', () {
-            var func = injector.getInstance(MyClassFunction);
-            expect(func, isNotNull);
-            expect(func(), equals('MyClass'));
-        });
+//        test('inject function', () {
+//            var func = injector.getInstance(MyFunction);
+//            expect(func, isNotNull);
+//            expect(func(), equals('MyFunction'));
+//        });
+//
+//        test('inject function in class', () {
+//            var func = injector.getInstance(MyClassFunction);
+//            expect(func, isNotNull);
+//            expect(func(), equals('MyClass'));
+//        });
 
         test('getInstance', () {
             var instance = injector.getInstance(MyClassToInject);
@@ -52,7 +63,7 @@ main() {
         test('resolveInjections', () {
             var instance = new MyClassToInject.inject(new MyClass());
             expect((instance as MyClassToInject).assertInjections(), isFalse);
-            
+
             var resolvedInstance = injector.resolveInjections(instance);
 
             expect((resolvedInstance as MyClassToInject).assertInjections(), isTrue);
@@ -106,6 +117,16 @@ main() {
             // installed Module overwrites the definition of MySingletonClass
             expect(singleton, new isInstanceOf<MySpecialSingletonClass2>());
         }); // end of '' test
+
+        test('> Class injection', () {
+            final Injector metaInjector = new Injector();
+
+            metaInjector.register(MyClass).toType(MetaTestClass);
+
+            final MyClass mc = metaInjector.getInstance(MyClass);
+            expect(mc, new isInstanceOf<MetaTestClass>());
+
+        }); // end of 'Class injection' test
 
     });
 

--- a/test/dice_test.dart
+++ b/test/dice_test.dart
@@ -119,16 +119,16 @@ main() {
 
         test('annotatedWith', () {
             final annotationInjector = new Injector()
-                ..register(String,annotatedWidth: UrlGoogle ).toInstance("http://www.google.com/")
+                ..register(String,annotatedWith: UrlGoogle ).toInstance("http://www.google.com/")
             ;
 
-            final String url = annotationInjector.getInstance(String,annotatedWidth: UrlGoogle);
+            final String url = annotationInjector.getInstance(String,annotatedWith: UrlGoogle);
             expect(url,"http://www.google.com/");
         });
 
         test('CTOR injection', () {
             final ctorInjector = new Injector()
-                ..register(String,annotatedWidth: UrlGoogle ).toInstance("http://www.google.com/")
+                ..register(String,annotatedWith: UrlGoogle ).toInstance("http://www.google.com/")
                 ..register(String,named: "language" ).toInstance("dart")
                 ..register(MyClass).toType(CTORInjection)
             ;

--- a/test/dice_test.dart
+++ b/test/dice_test.dart
@@ -6,16 +6,19 @@
 library dice_test;
 
 @MirrorsUsed(
-    metaTargets: const [ Inject ],
+    metaTargets: const [ Inject],
     symbols: const ['inject', 'Named'])
 import 'dart:mirrors';
 
 import 'package:test/test.dart';
 import 'package:dice/dice.dart';
 
+import 'config.dart';
 part 'src/test_module.dart';
 
 main() {
+    configLogging();
+
     group('injector -', () {
         final myModule = new MyModule();
         var injector = new Injector(myModule);
@@ -41,18 +44,6 @@ main() {
             expect(identical(instances[0], instances[1]), isFalse, reason: 'must be new instances');
         });
 
-//        test('inject function', () {
-//            var func = injector.getInstance(MyFunction);
-//            expect(func, isNotNull);
-//            expect(func(), equals('MyFunction'));
-//        });
-//
-//        test('inject function in class', () {
-//            var func = injector.getInstance(MyClassFunction);
-//            expect(func, isNotNull);
-//            expect(func(), equals('MyClass'));
-//        });
-
         test('getInstance', () {
             var instance = injector.getInstance(MyClassToInject);
             expect(instance, isNotNull);
@@ -72,7 +63,7 @@ main() {
 
         test('named injections', () {
             var myClass = injector.getInstance(MyClass);
-            var mySpecialClass = injector.getInstance(MyClass, "MySpecialClass");
+            var mySpecialClass = injector.getInstance(MyClass, named: "MySpecialClass");
             expect(myClass is MyClass, isTrue);
             expect(myClass is! MySpecialClass, isTrue);
             expect(mySpecialClass is MyClass, isTrue);
@@ -82,7 +73,7 @@ main() {
         test('get registrations', () {
             var registrations = injector.registrations;
             expect(registrations, isNotNull);
-            expect(() => registrations[new TypeMirrorWrapper(reflectType(MyClass), null)] = new Registration(MyClass),
+            expect(() => registrations[new TypeMirrorWrapper(reflectType(MyClass), null,null)] = new Registration(MyClass),
                 throwsUnsupportedError);
         });
 
@@ -92,20 +83,19 @@ main() {
 
             expect(singleton1.instanceID, 1);
             expect(singleton2.instanceID, 1);
-            expect(singleton1.hashCode,singleton2.hashCode);
-
+            expect(singleton1.hashCode, singleton2.hashCode);
         }); // end of 'asSingleton' test
 
         test('asSingleton II', () {
             final singletonModule = new MySingletonModule();
             var sInjector = new Injector(singletonModule);
 
-            var instances = [sInjector.getInstance(AnotherSingletonClass), sInjector.getInstance(AnotherSingletonClass)];
+            var instances = [sInjector.getInstance(AnotherSingletonClass), sInjector.getInstance(AnotherSingletonClass)
+            ];
             expect(instances, everyElement(isNotNull));
             expect(instances.first.getName(), equals('AnotherSingletonClass'));
             expect(identical(instances[0], instances[1]), isTrue, reason: 'must be singleton');
-            expect(instances[0].hashCode,instances[1].hashCode);
-
+            expect(instances[0].hashCode, instances[1].hashCode);
         }); // end of 'asSingleton' test
 
         test('MultiModule', () {
@@ -118,15 +108,23 @@ main() {
             expect(singleton, new isInstanceOf<MySpecialSingletonClass2>());
         }); // end of '' test
 
-        test('> Class injection', () {
+        test('Class injection', () {
             final Injector metaInjector = new Injector();
 
             metaInjector.register(MyClass).toType(MetaTestClass);
 
             final MyClass mc = metaInjector.getInstance(MyClass);
             expect(mc, new isInstanceOf<MetaTestClass>());
+        });
 
-        }); // end of 'Class injection' test
+        test('annotatedWith', () {
+            final annotationInjector = new Injector()
+                ..register(String,annotatedWidth: UrlGoogle ).toInstance("http://www.google.com/")
+            ;
+
+            final String url = annotationInjector.getInstance(String,annotatedWidth: UrlGoogle);
+            expect(url,"http://www.google.com/");
+        });
 
     });
 
@@ -157,7 +155,7 @@ main() {
             injector
                 ..register(MyClass).toType(MySpecialClass)
                 ..register(YourClass)..register(MyOtherClass)
-                ..register(MyClass, 'test').toType(MySpecialClass);
+                ..register(MyClass, named: 'test').toType(MySpecialClass);
 
             var myClass = injector.getInstance(MyClass);
             var yourClass = injector.getInstance(YourClass);
@@ -175,7 +173,7 @@ main() {
             expect(() => injector.getInstance(YourClass), throwsArgumentError);
             expect(() => injector.getInstance(MyOtherClass), throwsArgumentError);
 
-            var myNamedClass = injector.getInstance(MyClass, 'test');
+            var myNamedClass = injector.getInstance(MyClass, named: 'test');
             expect(myNamedClass, new isInstanceOf<MySpecialClass>());
         });
 
@@ -223,7 +221,15 @@ main() {
 
         test('variables', () {
             var variables = injector.injectableVariables(classMirror).toList().map((v) => symbolAsString(v.simpleName));
-            var expected = ['variableToInject', '_variableToInject', 'namedVariableToInject', '_namedVariableToInject'];
+            var expected = [
+                'variableToInject',
+                '_variableToInject',
+                'namedVariableToInject',
+                '_namedVariableToInject',
+                'url1',
+                'url2',
+                'url3'
+            ];
             expect(variables, unorderedEquals(expected));
         });
     });

--- a/test/dice_test.dart
+++ b/test/dice_test.dart
@@ -126,6 +126,17 @@ main() {
             expect(url,"http://www.google.com/");
         });
 
+        test('CTOR injection', () {
+            final ctorInjector = new Injector()
+                ..register(String,annotatedWidth: UrlGoogle ).toInstance("http://www.google.com/")
+                ..register(String,named: "language" ).toInstance("dart")
+                ..register(MyClass).toType(CTORInjection)
+            ;
+            final MyClass mc = ctorInjector.getInstance(MyClass);
+            expect(mc,isNotNull);
+            expect(mc.getName(),"CTORInjection - http://www.google.com/ (dart)");
+        }); // end of '' test
+
     });
 
     group('modules - ', () {

--- a/test/dice_vm_only_test.dart
+++ b/test/dice_vm_only_test.dart
@@ -13,6 +13,8 @@ import 'dart:mirrors';
 import 'package:test/test.dart';
 import 'package:dice/dice.dart';
 
+import 'config.dart';
+
 class MyModule extends Module {
 
     configure() {
@@ -34,8 +36,11 @@ class MyClass {
     String getName() => "MyClass";
 }
 
+
 // These tests don't work in Chrome (compiled to JS)
 main() {
+    configLogging();
+
     group('injector -', () {
         final myModule = new MyModule();
         var injector = new Injector(myModule);

--- a/test/dice_vm_only_test.dart
+++ b/test/dice_vm_only_test.dart
@@ -1,0 +1,55 @@
+// Copyright (c) 2013, the project authors. Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed
+// by a Apache license that can be found in the LICENSE file.
+
+@TestOn("!chrome")
+library dice_vm_only_test;
+
+@MirrorsUsed(
+    metaTargets: const [ Inject ],
+    symbols: const ['inject', 'Named'])
+import 'dart:mirrors';
+
+import 'package:test/test.dart';
+import 'package:dice/dice.dart';
+
+class MyModule extends Module {
+
+    configure() {
+        register(MyFunction).toFunction(MyFunctionToInject);
+        register(MyClassFunction).toFunction(new MyClass().getName);
+    }
+}
+
+@Inject()
+MyFunctionToInject() => "MyFunction";
+
+@Inject()
+typedef String MyFunction();
+
+@Inject()
+typedef String MyClassFunction();
+
+class MyClass {
+    String getName() => "MyClass";
+}
+
+// These tests don't work in Chrome (compiled to JS)
+main() {
+    group('injector -', () {
+        final myModule = new MyModule();
+        var injector = new Injector(myModule);
+
+        test('inject function', () {
+            var func = injector.getInstance(MyFunction);
+            expect(func, isNotNull);
+            expect(func(), equals('MyFunction'));
+        });
+
+        test('inject function in class', () {
+            var func = injector.getInstance(MyClassFunction);
+            expect(func, isNotNull);
+            expect(func(), equals('MyClass'));
+        });
+    });
+}

--- a/test/src/test_module.dart
+++ b/test/src/test_module.dart
@@ -19,8 +19,8 @@ class MyModule extends Module {
     register(String, named: "google").toInstance("http://www.google.com/");
 
     // annotated
-    register(String,annotatedWidth: UrlGoogle ).toInstance("http://www.google.com/");
-    register(String,annotatedWidth: UrlFacebook ).toInstance("http://www.facebook.com/");
+    register(String,annotatedWith: UrlGoogle ).toInstance("http://www.google.com/");
+    register(String,annotatedWith: UrlFacebook ).toInstance("http://www.facebook.com/");
   }
 }
 

--- a/test/src/test_module.dart
+++ b/test/src/test_module.dart
@@ -14,8 +14,13 @@ class MyModule extends Module {
     // Singleton
     register(MySingletonClass).toType(MySpecialSingletonClass).asSingleton();
 
-//    // named
-    register(MyClass, "MySpecialClass").toType(MySpecialClass);
+    // named
+    register(MyClass, named: "MySpecialClass").toType(MySpecialClass);
+    register(String, named: "google").toInstance("http://www.google.com/");
+
+    // annotated
+    register(String,annotatedWidth: UrlGoogle ).toInstance("http://www.google.com/");
+    register(String,annotatedWidth: UrlFacebook ).toInstance("http://www.facebook.com/");
   }
 }
 
@@ -84,6 +89,18 @@ class MyClassToInject {
   // Map to trace injections from setters or constructors
   Map injections = new Map();
 
+  @inject
+  @Named("google")
+  String url1;
+
+  @inject
+  @UrlGoogle()
+  String url2;
+
+  @inject
+  @UrlFacebook()
+  String url3;
+
   bool assertInjections() {
     // constructors
     var constructorsInjected = (injections[r'constructorParameterToInject'] != null);
@@ -94,13 +111,20 @@ class MyClassToInject {
     var namedVariablesToInject = (_namedVariableToInject != null && namedVariableToInject != null);
     var variablesInjected = variablesToInject && variablesNotToInject && namedVariablesToInject;
 
+    var stringInjectedByName = url1 != null && url1 == "http://www.google.com/";
+    var stringInjectedByAnnotation1 = url2 != null && url2 == "http://www.google.com/";
+    var stringInjectedByAnnotation2 = url3 != null && url3 == "http://www.facebook.com/";
+    //var stringInjectedByAnnotation1 = true;
+    //var stringInjectedByAnnotation2 = true;
+
     // setters
     // TODO && injections[r'_setterToInject'] != null
     var settersToInject = (injections[r'setterToInject'] != null);
     var settersNotToInject = (injections[r'setterNotToInject'] == null && injections[r'_setterNotToInject'] == null);
     var settersInjected = settersToInject && settersNotToInject;
 
-    return constructorsInjected && variablesInjected && settersInjected;
+    return constructorsInjected && variablesInjected && settersInjected && stringInjectedByName &&
+        stringInjectedByAnnotation1 && stringInjectedByAnnotation2;
   }
 }
 
@@ -124,7 +148,6 @@ class YourClass {
   String getName() => "YourClass";
 }
 
-//@Inject()
 class MySingletonClass {
     static int instanceCounter = 1;
 
@@ -157,4 +180,8 @@ class AnotherSingletonClass {
 class MetaTestClass extends MyClass {
     String getName() => "MetaTestClass";
 }
+
+// Class Annotations for URLs
+class UrlGoogle { const UrlGoogle(); }
+class UrlFacebook { const UrlFacebook(); }
 

--- a/test/src/test_module.dart
+++ b/test/src/test_module.dart
@@ -5,17 +5,16 @@
 part of dice_test;
 
 class MyModule extends Module {
+
   configure() {
     register(MyClass).toInstance(new MyClass());
     register(MyOtherClass).toBuilder(() => new MyOtherClass());
     register(MyClassToInject);
-    register(MyFunction).toFunction(MyFunctionToInject);
-    register(MyClassFunction).toFunction(new MyClass().getName);
 
     // Singleton
     register(MySingletonClass).toType(MySpecialSingletonClass).asSingleton();
 
-    // named
+//    // named
     register(MyClass, "MySpecialClass").toType(MySpecialClass);
   }
 }
@@ -43,6 +42,7 @@ class MyModuleForInstallation extends Module {
   }
 }
 
+@Inject()
 class MyClassToInject {
   // constructors
   @inject
@@ -104,22 +104,27 @@ class MyClassToInject {
   }
 }
 
+//@Inject()
 class MyClass {
   String getName() => "MyClass";
 }
 
+@Inject()
 class MyOtherClass {
   String getName() => "MyOtherClass";
 }
 
+@Inject()
 class MySpecialClass implements MyClass {
   String getName() => "MySpecialClass";
 }
 
+@Inject()
 class YourClass {
   String getName() => "YourClass";
 }
 
+//@Inject()
 class MySingletonClass {
     static int instanceCounter = 1;
 
@@ -133,19 +138,23 @@ class MySingletonClass {
     String getName() => "MySingletonClass - InstanceID: ${instanceID}";
 }
 
+@Inject()
 class MySpecialSingletonClass extends MySingletonClass {
     String getName() => "MySpecialSingletonClass - InstanceID: ${instanceID}";
 }
 
+@Inject()
 class MySpecialSingletonClass2 extends MySingletonClass {
     String getName() => "MySpecialSingletonClass2 - InstanceID: ${instanceID}";
 }
 
+@Inject()
 class AnotherSingletonClass {
     String getName() => "AnotherSingletonClass";
 }
 
-MyFunctionToInject() => "MyFunction";
+@Inject()
+class MetaTestClass extends MyClass {
+    String getName() => "MetaTestClass";
+}
 
-typedef String MyFunction();
-typedef String MyClassFunction();

--- a/test/src/test_module.dart
+++ b/test/src/test_module.dart
@@ -47,7 +47,7 @@ class MyModuleForInstallation extends Module {
   }
 }
 
-@Inject()
+@Injectable()
 class MyClassToInject {
   // constructors
   @inject
@@ -133,17 +133,17 @@ class MyClass {
   String getName() => "MyClass";
 }
 
-@Inject()
+@Injectable()
 class MyOtherClass {
   String getName() => "MyOtherClass";
 }
 
-@Inject()
+@Injectable()
 class MySpecialClass implements MyClass {
   String getName() => "MySpecialClass";
 }
 
-@Inject()
+@Injectable()
 class YourClass {
   String getName() => "YourClass";
 }
@@ -161,24 +161,37 @@ class MySingletonClass {
     String getName() => "MySingletonClass - InstanceID: ${instanceID}";
 }
 
-@Inject()
+@Injectable()
 class MySpecialSingletonClass extends MySingletonClass {
     String getName() => "MySpecialSingletonClass - InstanceID: ${instanceID}";
 }
 
-@Inject()
+@Injectable()
 class MySpecialSingletonClass2 extends MySingletonClass {
     String getName() => "MySpecialSingletonClass2 - InstanceID: ${instanceID}";
 }
 
-@Inject()
+@Injectable()
 class AnotherSingletonClass {
     String getName() => "AnotherSingletonClass";
 }
 
-@Inject()
+@Injectable()
 class MetaTestClass extends MyClass {
     String getName() => "MetaTestClass";
+}
+
+@Injectable()
+class CTORInjection extends MyClass {
+    final String url;
+    final String lang;
+
+    @inject
+    CTORInjection(@UrlGoogle() final String this.url,@Named("language") final String language)
+        : lang = language;
+
+    @override
+    String getName() => "CTORInjection - $url ($lang)";
 }
 
 // Class Annotations for URLs


### PR DESCRIPTION
Lib works now also with Chrome (compiled to JS)

try this: `pub run test -j 1 -p content-shell test` and `pub run test -j 1 -p chrome test`

I've added 
```dart
@MirrorsUsed(
    metaTargets: const [ Inject ],
    symbols: const ['inject', 'Named'])
import 'dart:mirrors';
```
in dice.dart let JS know the annotated classes.
