### PR TITLE
support bind multiple implementations to list

### DIFF
--- a/lib/src/Registration.dart
+++ b/lib/src/Registration.dart
@@ -9,56 +9,69 @@ typedef dynamic TypeBuilder();
 
 /// Registration between a [Type] and its instance creation.
 class Registration {
+  /// Create Registration defaulting to [type]
+  Registration(Type type) {
+    toType(type);
+  }
 
-    /// Create Registration defaulting to [type]
-    Registration(Type type) {
-        toType(type);
+  /// Register object [instance] that will be returned when the type is requested
+  void toInstance(var instance) {
+    if (!_isClass(instance)) {
+      throw new ArgumentError("only objects can be bound using 'toInstance'");
     }
+    _builder = () => instance;
+  }
 
-    /// Register object [instance] that will be returned when the type is requested
-    void toInstance(var instance) {
-        if (!_isClass(instance)) {
-            throw new ArgumentError("only objects can be bound using 'toInstance'");
-        }
-        _builder = () => instance;
+  /// Register a [function] that will be returned when the type is requested
+  void toFunction(var function) {
+    if (_isClass(function)) {
+      throw new ArgumentError("only functions can be bound using 'toFunction'");
     }
+    _builder = () => function;
+  }
 
-    /// Register a [function] that will be returned when the type is requested
-    void toFunction(var function) {
-        if (_isClass(function)) {
-            throw new ArgumentError("only functions can be bound using 'toFunction'");
-        }
-        _builder = () => function;
-    }
+  /// Register a [InstanceBuilder] that will emit new instances when the type is requested
+  void toBuilder(TypeBuilder builder) {
+    _builder = builder;
+  }
 
-    /// Register a [InstanceBuilder] that will emit new instances when the type is requested
-    void toBuilder(TypeBuilder builder) {
-        _builder = builder;
-    }
+  /// Register a [type] that will be instantiated when the type is requested
+  Registration toType(Type type) {
+    _builder = () => type;
+    return this;
+  }
 
-    /// Register a [type] that will be instantiated when the type is requested
-    Registration toType(Type type) {
-        _builder = () => type;
-        return this;
-    }
+  /// Most common way to register something.
+  /// This is a shortcut to [toType]
+  Registration to(Type type) => toType(type);
 
-    /// Most common way to register something.
-    /// This is a shortcut to [toType]
-    Registration to(Type type) => toType(type);
+  /// Create only one instance
+  void asSingleton() {
+    _asSingleton = true;
+  }
 
-    /// Create only one instance
-    void asSingleton() {
-        _asSingleton = true;
-    }
+  bool _isClass(var instance) => reflect(instance).type is! FunctionTypeMirror;
 
-    bool _isClass(var instance) => reflect(instance).type is! FunctionTypeMirror;
+  TypeBuilder _builder;
 
-    TypeBuilder _builder;
+  bool _asSingleton = false;
 
-    bool _asSingleton = false;
-
-    /// Remember the instance in case we marked the Registration for "singleton"
-    var _instance = null;
+  /// Remember the instance in case we marked the Registration for "singleton"
+  var _instance = null;
 }
 
+class RegistrationMulti extends Registration {
+  Set<Registration> _registrations = new Set();
 
+  /// Create Registration defaulting to [type]
+  RegistrationMulti(Type type) : super(type);
+
+  bool _asSingleton = true;
+
+  /// Remember the instance in case we marked the Registration for "singleton"
+  var _instance = null;
+
+  void addRegistration(Registration registration) {
+    _registrations.add(registration);
+  }
+}

--- a/lib/src/mirror_util.dart
+++ b/lib/src/mirror_util.dart
@@ -19,8 +19,12 @@ class TypeMirrorWrapper {
         : typeMirror = reflectType(type),
             annotationTypeMirror = annotation != null ? reflectType(annotation) : null;
 
+    TypeMirrorWrapper.fromListType(final Type type, this.name, final Type annotation)
+        : typeMirror = reflectType(List, [type]),
+            annotationTypeMirror = annotation != null ? reflectType(annotation) : null;
+
     String get qualifiedName =>
-        symbolAsString(typeMirror.qualifiedName)
+        symbolAsString(typeMirror.qualifiedName)+"<"+typeMirror.typeArguments.toString()+">"
             + (name != null ? "#$name" : "")
             + (annotationTypeMirror != null
                 ? "#${symbolAsString(annotationTypeMirror.qualifiedName)}" : "");

--- a/test/dice_test.dart
+++ b/test/dice_test.dart
@@ -9,6 +9,7 @@ library dice_test;
     metaTargets: const [ Inject],
     symbols: const ['inject', 'Named'])
 import 'dart:mirrors';
+import 'package:collection/collection.dart';
 
 import 'package:test/test.dart';
 import 'package:dice/dice.dart';
@@ -49,6 +50,15 @@ main() {
             expect(instance, isNotNull);
             expect(instance, new isInstanceOf<MyClassToInject>());
             expect((instance as MyClassToInject).assertInjections(), isTrue);
+        });
+
+        test('getInstanceMulti', () {
+            var instance = injector.getMultiInstance(int, named: "multi");
+            expect(instance, isNotNull);
+            expect(instance, new isInstanceOf<List<int>>());
+            expect((instance as List<int>), [1,2]);
+            var my = injector.getInstance(MyClassToInject);
+            expect((my as MyClassToInject).assertInjections(), isTrue);
         });
 
         test('resolveInjections', () {
@@ -119,6 +129,17 @@ main() {
             expect(singleton, new isInstanceOf<MySpecialSingletonClass2>());
         }); // end of '' test
 
+        test('getInstanceMulti with MultiModule', () {
+            final myMultiModule = new MyModuleForInstallation();
+            var multiInjector = new Injector(myMultiModule);
+            var instance = multiInjector.getMultiInstance(int, named: "multi");
+            expect(instance, isNotNull);
+            expect(instance, new isInstanceOf<List<int>>());
+            expect((instance as List<int>), [1,2,3]);
+            var my = injector.getInstance(MyClassToInject);
+            expect((my as MyClassToInject).assertInjections(), isTrue);
+        });
+
         test('Class injection', () {
             final Injector metaInjector = new Injector();
 
@@ -172,6 +193,16 @@ main() {
 
             expect(myClass, new isInstanceOf<MyClass>());
             expect(yourClass, new isInstanceOf<YourClass>());
+        });
+        test('getInstanceMulti with MultiModule', () {
+            var injector = new Injector.fromModules([new YourModule(), new MyModule()]);
+
+            var instance = injector.getMultiInstance(int, named: "multi");
+            expect(instance, isNotNull);
+            expect(instance, new isInstanceOf<List<int>>());
+            expect((instance as List<int>), [1,2,4]);
+            var my = injector.getInstance(MyClassToInject);
+            expect((my as MyClassToInject).assertInjections(), isTrue);
         });
 
         test('register runtime', () {
@@ -260,7 +291,8 @@ main() {
                 '_namedVariableToInject',
                 'url1',
                 'url2',
-                'url3'
+                'url3',
+                'multi'
             ];
             expect(variables, unorderedEquals(expected));
         });

--- a/test/src/test_module.dart
+++ b/test/src/test_module.dart
@@ -21,12 +21,17 @@ class MyModule extends Module {
     // annotated
     register(String,annotatedWith: UrlGoogle ).toInstance("http://www.google.com/");
     register(String,annotatedWith: UrlFacebook ).toInstance("http://www.facebook.com/");
+
+    registerMulti(int, named: "multi").toInstance(1);
+    registerMulti(int, named: "multi").toInstance(2);
+
   }
 }
 
 class YourModule extends Module {
   configure() {
     register(YourClass).toType(YourClass);
+    registerMulti(int, named: "multi").toInstance(4);
   }
 }
 
@@ -42,8 +47,8 @@ class MyModuleForInstallation extends Module {
   @override
   configure() {
     install(new MyModule());
-
     register(MySingletonClass).toType(MySpecialSingletonClass2);
+    registerMulti(int, named: "multi").toInstance(3);
   }
 }
 
@@ -101,6 +106,10 @@ class MyClassToInject {
   @UrlFacebook()
   String url3;
 
+  @inject
+  @Named("multi")
+  List<int> multi;
+
   bool assertInjections() {
     // constructors
     var constructorsInjected = (injections[r'constructorParameterToInject'] != null);
@@ -120,9 +129,8 @@ class MyClassToInject {
     var settersToInject = (injections[r'setterToInject'] != null);
     var settersNotToInject = (injections[r'setterNotToInject'] == null && injections[r'_setterNotToInject'] == null);
     var settersInjected = settersToInject && settersNotToInject;
-
     return constructorsInjected && variablesInjected && settersInjected && stringInjectedByName &&
-        stringInjectedByAnnotation1 && stringInjectedByAnnotation2;
+        stringInjectedByAnnotation1 && stringInjectedByAnnotation2 ;
   }
 }
 


### PR DESCRIPTION
May be it has some worth to bind multiple implementations to a same type.

```
registerMulti(int, named: "multi").toInstance(1);
registerMulti(int, named: "multi").toInstance(2);

var instance = injector.getMultiInstance(int, named: "multi");

```